### PR TITLE
:passport_control: fix: 認可チェックを追加

### DIFF
--- a/src/pages/heatmap/tasks/[task_id]/HeatmapTasksTaskId.page.tsx
+++ b/src/pages/heatmap/tasks/[task_id]/HeatmapTasksTaskId.page.tsx
@@ -25,8 +25,10 @@ const Component: FC<HeatMapTaskIdPageProps> = ({ className }) => {
   const { isAuthorized, isLoading } = useAuth();
 
   const { data: task, refetch: refetchTask } = useQuery({
-    queryKey: ['heatmap', taskId],
+    queryKey: ['heatmap', taskId, isAuthorized],
     queryFn: async (): Promise<HeatmapTask | undefined> => {
+      if (!taskId || isNaN(Number(taskId))) return undefined;
+      if (!isAuthorized) return undefined;
       const { data, error } = await query.GET('/api/v0/heatmap/tasks/{task_id}', {
         params: { path: { task_id: Number(taskId) } },
       });

--- a/src/pages/home/home.page.tsx
+++ b/src/pages/home/home.page.tsx
@@ -37,8 +37,9 @@ const Component: FC<HomePageProps> = ({ className }) => {
     isError: isErrorProjects,
     fetchNextPage: fetchNextPageProjects,
   } = useInfiniteQuery({
-    queryKey: ['projects'],
+    queryKey: ['projects', isAuthorized],
     queryFn: async ({ pageParam }): Promise<Project[] | undefined> => {
+      if (!isAuthorized) return undefined;
       const { data, error } = await query.GET('/api/v0/projects', {
         params: {
           query: {


### PR DESCRIPTION
`isAuthorized`を用いて、APIクエリ実行前にユーザー認可を確認する処理を追加。これにより、不正なアクセスや無効なリクエストを防止。