### PR TITLE
:dizzy: feat: Heatmapの透過設定を追加

### DIFF
--- a/src/modeles/heatmapView.ts
+++ b/src/modeles/heatmapView.ts
@@ -24,6 +24,7 @@ export type GeneralSettings = {
   upZ: boolean;
   scale: number;
   showHeatmap: boolean;
+  heatmapOpacity: number;
   blockSize: number;
   mapName: string;
   minThreshold: number;
@@ -68,6 +69,7 @@ export const initializeValues: HeatmapDataState = {
     upZ: true,
     scale: 1,
     showHeatmap: false,
+    heatmapOpacity: 1.0,
     blockSize: 1,
     mapName: '',
     minThreshold: 0.0,

--- a/src/pages/heatmap/tasks/[task_id]/HeatmapCanvas.tsx
+++ b/src/pages/heatmap/tasks/[task_id]/HeatmapCanvas.tsx
@@ -3,7 +3,7 @@ import { useThree } from '@react-three/fiber';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Raycaster, Vector2, Vector3 } from 'three';
 
-import { PositionPointMarkers } from './PositionPointMarkers';
+import { HeatmapPointsMarker } from './HeatmapPointsMarker';
 
 import type { PlayerTimelinePointsTimeRange } from '@src/pages/heatmap/tasks/[task_id]/PlayerTimelinePoints';
 import type { HeatmapDataService } from '@src/utils/heatmap/HeatmapDataService';
@@ -190,7 +190,7 @@ const Component: FC<HeatmapCanvasProps> = ({ model, map, modelType, pointList, s
       <directionalLight position={[10, 10, 10]} intensity={3} castShadow={true} /* eslint-disable-line react/no-unknown-property */ />
       {modelType && map && modelType !== 'server' && typeof map === 'string' && <LocalModelLoader ref={modelRef} modelPath={map} modelType={modelType} />}
       {modelType && model && modelType === 'server' && typeof map !== 'string' && <StreamModelLoader ref={modelRef} model={model} />}
-      {pointList && showHeatmap && <PositionPointMarkers points={pointList} />}
+      {pointList && showHeatmap && <HeatmapPointsMarker points={pointList} />}
       {pointList && showHeatmap && <HotspotCircles points={pointList} />}
       {visibleEventLogs.length > 0 && visibleEventLogs.map((event) => <EventLogMarkers key={event.key} logName={event.key} service={service} pref={event} />)}
       {service &&

--- a/src/pages/heatmap/tasks/[task_id]/HeatmapPointsMarker.tsx
+++ b/src/pages/heatmap/tasks/[task_id]/HeatmapPointsMarker.tsx
@@ -43,7 +43,7 @@ class Point extends Vector3 {
 
 const Component: FC<PointMarkersProps> = ({ points, colorIntensity = 0.9, colorScale = 1 }) => {
   const {
-    data: { upZ, scale, minThreshold = 0.0, maxThreshold = 1.0 },
+    data: { upZ, scale, minThreshold = 0.0, maxThreshold = 1.0, heatmapOpacity = 1.0 },
   } = useGeneralState();
 
   // Z-up / Y-up の変換
@@ -119,11 +119,11 @@ const Component: FC<PointMarkersProps> = ({ points, colorIntensity = 0.9, colorS
           receiveShadow={false} /* eslint-disable-line react/no-unknown-property */
         >
           <boxGeometry args={[50 * scale, 50 * scale, 50 * scale]} /> {/* eslint-disable-line react/no-unknown-property */}
-          <meshStandardMaterial color={pos.color} />
+          <meshStandardMaterial color={pos.color} opacity={heatmapOpacity} transparent={true} /> {/* eslint-disable-line react/no-unknown-property */}
         </mesh>
       ))}
     </>
   );
 };
 
-export const PositionPointMarkers = Component;
+export const HeatmapPointsMarker = Component;

--- a/src/pages/heatmap/tasks/[task_id]/PointMarkers.stories.tsx
+++ b/src/pages/heatmap/tasks/[task_id]/PointMarkers.stories.tsx
@@ -1,7 +1,7 @@
 import { OrbitControls } from '@react-three/drei';
 import { Canvas } from '@react-three/fiber';
 
-import { PositionPointMarkers } from './PositionPointMarkers';
+import { HeatmapPointsMarker } from './HeatmapPointsMarker';
 
 import type { Meta, StoryObj } from '@storybook/react';
 
@@ -10,10 +10,10 @@ import darkTheme from '@src/styles/dark';
 import lightTheme from '@src/styles/light';
 
 export default {
-  component: PositionPointMarkers,
+  component: HeatmapPointsMarker,
   controls: { hideNoControlsWarning: true },
 } as Meta;
-type Story = StoryObj<typeof PositionPointMarkers>;
+type Story = StoryObj<typeof HeatmapPointsMarker>;
 
 const Template: Story = {
   render: (args) => {
@@ -25,7 +25,7 @@ const Template: Story = {
           <Canvas camera={{ position: [3, 3, 3], fov: 75 }}>
             <ambientLight intensity={0.5} /> {/* eslint-disable-line react/no-unknown-property */}
             <directionalLight position={[10, 10, 10]} intensity={1} /> {/* eslint-disable-line react/no-unknown-property */}
-            <PositionPointMarkers {...args} />
+            <HeatmapPointsMarker {...args} />
             {/* カメラ移動・回転を可能にする */}
             <OrbitControls
               enableZoom={true} // ズーム可能

--- a/src/pages/heatmap/tasks/[task_id]/menu/GeneralMenuContent.tsx
+++ b/src/pages/heatmap/tasks/[task_id]/menu/GeneralMenuContent.tsx
@@ -36,6 +36,18 @@ export const GeneralMenuContent: FC<HeatmapMenuProps> = () => {
           <Switch label={'showHeatmap'} onChange={(showHeatmap) => setData({ ...general, showHeatmap })} checked={general.showHeatmap} size={'small'} />
         </div>
       </InputRow>
+      <InputRow label={'opacity'}>
+        <div>
+          <Slider
+            value={general.heatmapOpacity}
+            min={0.0}
+            max={1.0}
+            step={0.1}
+            onChange={(value) => setData({ ...general, heatmapOpacity: value })}
+            disabled={!general.showHeatmap}
+          />
+        </div>
+      </InputRow>
       <InputColumn label={'blockSize'}>
         <Slider value={general.blockSize} onChange={(blockSize) => setData({ ...general, blockSize })} min={50} step={50} max={500} sideLabel textField />
       </InputColumn>


### PR DESCRIPTION
`heatmapOpacity`プロパティを導入し、透過設定用のスライダーを追加しました。これにより、Heatmapの表示がより柔軟に調整可能になりました。