### PR TITLE
:wrench: chore: Add read-only content permissions for workflows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,9 @@ on:
       - 'package-lock.json'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
     group: 'pr-workflow-${{ github.head_ref }}'
     cancel-in-progress: true


### PR DESCRIPTION
Updated the GitHub Actions workflow permissions to restrict content access to read-only. Helps improve workflow security and adheres to best practices.