### PR TITLE
:dizzy: feat: Simplify markdown file handling in index.page

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,13 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   pageExtensions: ['page.tsx', 'page.ts', 'api.ts'],
   output: 'standalone',
+  webpack(config) {
+    config.module.rules.push({
+      test: /\.md$/i,
+      type: 'asset/source',
+    });
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -1,5 +1,3 @@
-import { promises as fs } from 'fs';
-
 import styled from '@emotion/styled';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -10,6 +8,7 @@ import remarkGfm from 'remark-gfm';
 import type { FC } from 'react';
 
 import { Header } from '@src/component/templates/Header';
+import readmeRaw from '@src/files/heatmapReadme.md';
 import { dimensions } from '@src/styles/style';
 
 export type IndexPageProps = {
@@ -19,13 +18,7 @@ export type IndexPageProps = {
 
 export async function getServerSideProps() {
   try {
-    const readmeRaw = await fs.readFile(process.cwd() + '/src/files/heatmapReadme.md', 'utf8');
-    return {
-      props: {
-        title: 'Index Page',
-        readme: readmeRaw,
-      },
-    };
+    return { props: { title: 'Index Page', readme: readmeRaw } };
   } catch {
     return {
       notFound: true,


### PR DESCRIPTION
Replaced `fs.readFile` with direct import of markdown as a module. Added a webpack configuration to handle `.md` files. This optimizes file usage and simplifies server-side code.