### PR TITLE
🧹 Remove commented out hvqlCompiler code in EventLogMarkers

### DIFF
--- a/src/features/heatmap/EventLogMarkers.tsx
+++ b/src/features/heatmap/EventLogMarkers.tsx
@@ -148,16 +148,6 @@ const EventLogMarkers: FC<EventLogMarkersProps> = ({ logName, service, pref }) =
   // Timeline state for time-based filtering
   const { visible: isTimelineActive, currentTimelineSeek } = usePlayerTimelinePick('visible', 'currentTimelineSeek');
 
-  // Compile HVQL script if provided
-  // const hvqlCompiler = useMemo(() => {
-  //   if (!hvqlScript) return null;
-  //   try {
-  //     return compileHVQL(hvqlScript);
-  //   } catch {
-  //     return null;
-  //   }
-  // }, [hvqlScript]);
-
   // テクスチャキャッシュ
   const textureCache = useRef<Map<string, Texture>>(new Map());
   const spriteRef = useRef<Sprite | null>(null);


### PR DESCRIPTION
🎯 **What:** Removed the commented-out `hvqlCompiler` variable block in `src/features/heatmap/EventLogMarkers.tsx`.
💡 **Why:** The commented-out code was unused and removing it improves code readability and maintainability.
✅ **Verification:** Verified with `bun test` and Prettier format checking. Restored `package.json` and `bun.lock` to ensure only the target file was affected.
✨ **Result:** A cleaner `EventLogMarkers.tsx` without dead code.

---
*PR created automatically by Jules for task [3331459172167420018](https://jules.google.com/task/3331459172167420018) started by @matuyuhi*