### PR TITLE
🔒 Fix hardcoded CSRF secret fallback in production

### DIFF
--- a/src/utils/security/csrf.ts
+++ b/src/utils/security/csrf.ts
@@ -61,8 +61,17 @@ export function verifyCsrfToken(token: string, signature: string, secret: string
 
 /**
  * CSRF secret key (should be set in environment variables)
- * Falls back to a default value for development
+ * Falls back to a default value for development, throws in production if not set
  */
 export function getCsrfSecret(): string {
-  return process.env.CSRF_SECRET || 'default-csrf-secret-please-change-in-production-min-32-chars';
+  const secret = process.env.CSRF_SECRET;
+
+  if (!secret) {
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error('CSRF_SECRET environment variable is missing and is required in production.');
+    }
+    return 'default-csrf-secret-please-change-in-production-min-32-chars';
+  }
+
+  return secret;
 }


### PR DESCRIPTION
🎯 **What:** Fixed a vulnerability where `getCsrfSecret()` fell back to a hardcoded string if `process.env.CSRF_SECRET` was missing.
⚠️ **Risk:** The hardcoded secret provides a false sense of security and exposes the application to CSRF attacks if deployed to production without the secret configured properly.
🛡️ **Solution:** Updated the function to "fail-closed" by throwing an Error in production if the secret is missing, while retaining the convenient fallback in development environments.

---
*PR created automatically by Jules for task [17742776759043660858](https://jules.google.com/task/17742776759043660858) started by @matuyuhi*