### PR TITLE
🧪 add tests for isDocFile in docs parser

### DIFF
--- a/src/utils/docs/parser.test.ts
+++ b/src/utils/docs/parser.test.ts
@@ -1,0 +1,25 @@
+import { isDocFile } from './parser';
+
+describe('isDocFile', () => {
+  test('returns true for regular markdown files', () => {
+    expect(isDocFile('document.md')).toBe(true);
+    expect(isDocFile('path/to/file.md')).toBe(true);
+    expect(isDocFile('index.md')).toBe(true);
+  });
+
+  test('returns false for files that do not end with .md', () => {
+    expect(isDocFile('document.txt')).toBe(false);
+    expect(isDocFile('file.mdx')).toBe(false);
+    expect(isDocFile('image.png')).toBe(false);
+    expect(isDocFile('readme.MD')).toBe(false); // Since endsWith is case-sensitive
+  });
+
+  test('returns false for hidden files (starting with a dot)', () => {
+    expect(isDocFile('.hidden.md')).toBe(false);
+    expect(isDocFile('.env')).toBe(false);
+  });
+
+  test('returns false for empty string', () => {
+    expect(isDocFile('')).toBe(false);
+  });
+});


### PR DESCRIPTION
🎯 **What:** Added tests for the previously untested pure function `isDocFile` inside `src/utils/docs/parser.ts`.
📊 **Coverage:** 
- Happy paths: Typical markdown filenames (`.md`).
- Negative paths: Other extensions (`.mdx`, `.txt`), uppercase extensions (`.MD`).
- Edge cases: Hidden files starting with `.`, empty strings.
✨ **Result:** Test coverage for this helper function is now fully covered, increasing overall codebase reliability.

---
*PR created automatically by Jules for task [9269020335243290500](https://jules.google.com/task/9269020335243290500) started by @matuyuhi*