### PR TITLE
🧹 Remove console.log from TimelineControllerBlock.stories.tsx

### DIFF
--- a/src/component/templates/TimelineControllerBlock.stories.tsx
+++ b/src/component/templates/TimelineControllerBlock.stories.tsx
@@ -8,6 +8,10 @@ import { TimelineControllerBlock } from '@src/component/templates/TimelineContro
 export default {
   component: TimelineControllerBlock,
   controls: { hideNoControlsWarning: true },
+  argTypes: {
+    onClickMenu: { action: 'onClickMenu' },
+    onClickPlay: { action: 'onClickPlay' },
+  },
 } as Meta;
 
 type Story = StoryObj<typeof TimelineControllerBlock>;
@@ -44,14 +48,5 @@ export const Default: Story = {
   name: 'default style',
   args: {
     isPlaying: false,
-
-    onClickMenu: () => {
-      /* eslint-disable-next-line no-console */
-      console.log('Menu clicked');
-    },
-    onClickPlay: () => {
-      /* eslint-disable-next-line no-console */
-      console.log('Play/Pause clicked');
-    },
   },
 };


### PR DESCRIPTION
🎯 **What:** Removed `console.log` statements from `src/component/templates/TimelineControllerBlock.stories.tsx`.
💡 **Why:** `console.log` statements left in the codebase clutter standard output and can reduce code hygiene. In Storybook, it is considered better practice to use `argTypes` mapping to `action` loggers instead.
✅ **Verification:** Ran `bun test` and `bun run lint` successfully to ensure no regressions were introduced.
✨ **Result:** A cleaner codebase with proper idiomatic Storybook event logging via the "Actions" tab instead of standard browser consoles.

---
*PR created automatically by Jules for task [942339283964279993](https://jules.google.com/task/942339283964279993) started by @matuyuhi*