### PR TITLE
chore: disable Argos screenshot upload in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -96,7 +96,3 @@ jobs:
           bunx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
             "bunx http-server storybook-static --port 6006 --silent" \
             "bunx wait-on tcp:6006 && NODE_NO_WARNINGS=1 NODE_OPTIONS=--experimental-vm-modules bun run test-storybook"
-
-      - name: Upload screenshots to Argos
-        continue-on-error: true
-        run: bunx argos upload ./screenshots --token ${{ secrets.ARGOS_TOKEN }}


### PR DESCRIPTION
## Summary
- \`storybook-test\` ジョブの「Upload screenshots to Argos」step を削除し、Argos の CI チェックを無効化します
- 直近の open PR 全てで Argos が FAILURE 判定となっており、他のチェック (check / storybook-test) が green でも PR ステータスが赤になる状態でした
- 一旦 off にして、設定見直し後に必要なら再有効化します

## Test plan
- [ ] CI 実行で argos の step が消えていることを確認
- [ ] 既存の check / storybook-test ジョブが従来通り動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)