### PR TITLE
🧹 [Code Health] Remove console.log from useOfflineHeatmapDataService

### DIFF
--- a/src/utils/heatmap/useOfflineHeatmapDataService.ts
+++ b/src/utils/heatmap/useOfflineHeatmapDataService.ts
@@ -23,9 +23,6 @@ export function useOfflineHeatmapDataService(offlineData: OfflineHeatmapData | n
 
       try {
         // Base64エンコードされたデータをデコード
-        // eslint-disable-next-line no-console
-        console.log('Base64エンコードされたモデルデータを処理中...');
-
         // Base64文字列をバイナリデータに変換
         const binaryString = atob(data.mapContentBase64);
         const len = binaryString.length;


### PR DESCRIPTION
🎯 **What:** Removed a `console.log` statement (and its accompanying `eslint-disable` comment) from `useOfflineHeatmapDataService.ts`.
💡 **Why:** To improve code hygiene and reduce console noise in production. Console logs shouldn't generally be left in production code unless they are explicitly meant for debugging/logging, and this one was specifically noting that base64 encoded model data was being processed.
✅ **Verification:** Ran `bun run lint` (using individual commands), `bun run format`, and `bun test` to ensure that this change introduced no regressions and adhered to the code formatting guidelines.
✨ **Result:** A cleaner codebase with reduced console output when using the offline heatmap feature.

---
*PR created automatically by Jules for task [7452767067030339348](https://jules.google.com/task/7452767067030339348) started by @matuyuhi*