### PR TITLE
🧹 Refactor: Remove commented out code from EventLogMarkers

### DIFF
--- a/src/features/heatmap/EventLogMarkers.tsx
+++ b/src/features/heatmap/EventLogMarkers.tsx
@@ -328,32 +328,6 @@ const EventLogMarkers: FC<EventLogMarkersProps> = ({ logName, service, pref }) =
     };
   }, [logName]);
 
-  // Helper function to get icon name based on HVQL or fallback
-  // const getIconNameForMarker = useCallback(
-  //   (metadata: Record<string, any> | undefined): string | undefined => {
-  //     if (!metadata) return iconName;
-  //
-  //     if (hvqlCompiler) {
-  //       try {
-  //         const ctx: ViewContext = {
-  //           player: 0,
-  //           status: metadata,
-  //           pos: { x: 0, y: 0, z: 0 },
-  //           t: 0,
-  //         };
-  //         const style = hvqlCompiler(ctx);
-  //         return style.icon || iconName;
-  //       } catch (e) {
-  //         console.error('Error applying HVQL:', e);
-  //         return iconName;
-  //       }
-  //     }
-  //
-  //     return iconName;
-  //   },
-  //   [hvqlCompiler, iconName],
-  // );
-
   return (
     <>
       {visibleWorldPositions.map((d) => (


### PR DESCRIPTION
🎯 **What:** Removed commented-out code (`getIconNameForMarker`) from `src/features/heatmap/EventLogMarkers.tsx`.
💡 **Why:** To improve codebase maintainability and readability by cleaning up dead code.
✅ **Verification:** Verified by running the standard testing suite and format checks (`bun test` and `bun run format:check`), both of which passed and confirmed no regressions or formatting issues were introduced. Also confirmed removal correctly using file readers.
✨ **Result:** Cleaned up code without any change in functionality.

---
*PR created automatically by Jules for task [869365061510601568](https://jules.google.com/task/869365061510601568) started by @matuyuhi*