### PR TITLE
🧹 Refactor: Remove commented out code in EventLogMarkers.tsx

### DIFF
--- a/src/features/heatmap/EventLogMarkers.tsx
+++ b/src/features/heatmap/EventLogMarkers.tsx
@@ -328,32 +328,6 @@ const EventLogMarkers: FC<EventLogMarkersProps> = ({ logName, service, pref }) =
     };
   }, [logName]);
 
-  // Helper function to get icon name based on HVQL or fallback
-  // const getIconNameForMarker = useCallback(
-  //   (metadata: Record<string, any> | undefined): string | undefined => {
-  //     if (!metadata) return iconName;
-  //
-  //     if (hvqlCompiler) {
-  //       try {
-  //         const ctx: ViewContext = {
-  //           player: 0,
-  //           status: metadata,
-  //           pos: { x: 0, y: 0, z: 0 },
-  //           t: 0,
-  //         };
-  //         const style = hvqlCompiler(ctx);
-  //         return style.icon || iconName;
-  //       } catch (e) {
-  //         console.error('Error applying HVQL:', e);
-  //         return iconName;
-  //       }
-  //     }
-  //
-  //     return iconName;
-  //   },
-  //   [hvqlCompiler, iconName],
-  // );
-
   return (
     <>
       {visibleWorldPositions.map((d) => (


### PR DESCRIPTION
🎯 **What:** Removed commented out code (`getIconNameForMarker` helper function) from `src/features/heatmap/EventLogMarkers.tsx`.
💡 **Why:** Commented-out code causes noise, reducing the readability and maintainability of the codebase. By removing it, the intention of the file becomes clearer without distraction.
✅ **Verification:** Verified by checking the file contents with `read_file`, ensuring no syntax errors were introduced, running the test suite via `bun test`, and running the linter using `bun run lint`.
✨ **Result:** A cleaner, more readable, and easier-to-maintain codebase.

---
*PR created automatically by Jules for task [1792025808109852221](https://jules.google.com/task/1792025808109852221) started by @matuyuhi*