### PR TITLE
🧹 chore: remove console.log from Slider.stories.tsx

### DIFF
--- a/src/component/atoms/Slider.stories.tsx
+++ b/src/component/atoms/Slider.stories.tsx
@@ -7,19 +7,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 export default {
   component: Slider,
   controls: { hideNoControlsWarning: true },
+  argTypes: { onChange: { action: 'onChange' } },
 } as Meta;
 type Story = StoryObj<typeof Slider>;
 
 const Template: Story = {
   render: (args) => (
     <div style={{ width: '300px', padding: '16px' }}>
-      <Slider
-        {...args}
-        onChange={(value) => {
-          /* eslint-disable-next-line no-console */
-          console.log('Slider value:', value);
-        }}
-      />
+      <Slider {...args} />
       <Text text={`Value: ${args.value}`} />
     </div>
   ),


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed explicit `console.log` from `onChange` prop in `src/component/atoms/Slider.stories.tsx` and replaced it with a Storybook action via `argTypes: { onChange: { action: 'onChange' } }`.

💡 **Why:** How this improves maintainability
Console logs can clutter browser console outputs and are generally not recommended in Storybook stories when native actions are available. By using `argTypes`, the action is correctly surfaced in the Storybook Actions panel without hardcoding logs into the file.

✅ **Verification:** How you confirmed the change is safe
Ran `bun run lint`, `bun run format:check`, and `bun test` to ensure formatting is correct and there are no regressions. Visual inspection via `cat` confirmed the diff was applied properly.

✨ **Result:** The improvement achieved
A cleaner `Slider.stories.tsx` that leverages Storybook's built-in actions features over explicit `console.log`s.

---
*PR created automatically by Jules for task [4421695550382085123](https://jules.google.com/task/4421695550382085123) started by @matuyuhi*