### PR TITLE
🧹 [code health] Remove commented out code in EventLogMarkers

### DIFF
--- a/src/features/heatmap/EventLogMarkers.tsx
+++ b/src/features/heatmap/EventLogMarkers.tsx
@@ -328,32 +328,6 @@ const EventLogMarkers: FC<EventLogMarkersProps> = ({ logName, service, pref }) =
     };
   }, [logName]);
 
-  // Helper function to get icon name based on HVQL or fallback
-  // const getIconNameForMarker = useCallback(
-  //   (metadata: Record<string, any> | undefined): string | undefined => {
-  //     if (!metadata) return iconName;
-  //
-  //     if (hvqlCompiler) {
-  //       try {
-  //         const ctx: ViewContext = {
-  //           player: 0,
-  //           status: metadata,
-  //           pos: { x: 0, y: 0, z: 0 },
-  //           t: 0,
-  //         };
-  //         const style = hvqlCompiler(ctx);
-  //         return style.icon || iconName;
-  //       } catch (e) {
-  //         console.error('Error applying HVQL:', e);
-  //         return iconName;
-  //       }
-  //     }
-  //
-  //     return iconName;
-  //   },
-  //   [hvqlCompiler, iconName],
-  // );
-
   return (
     <>
       {visibleWorldPositions.map((d) => (


### PR DESCRIPTION
🎯 **What:** Removed the commented-out `getIconNameForMarker` function in `src/features/heatmap/EventLogMarkers.tsx`.
💡 **Why:** Dead code clutter creates noise, reduces readability, and can confuse developers about whether the code is meant to be reinstated. Removing it improves overall codebase maintainability without affecting functionality.
✅ **Verification:** Verified by running the format check, TypeScript type check, linting suite, and test suite. Also read through the file using `sed` to verify that formatting is intact and the correct lines were removed.
✨ **Result:** A cleaner and more readable `EventLogMarkers.tsx` file.

---
*PR created automatically by Jules for task [7790268092948973731](https://jules.google.com/task/7790268092948973731) started by @matuyuhi*