### PR TITLE
🧹 Remove commented out code in HeatmapViewer

### DIFF
--- a/src/features/heatmap/HeatmapViewer.tsx
+++ b/src/features/heatmap/HeatmapViewer.tsx
@@ -88,7 +88,6 @@ const Component: FC<HeatmapViewerProps> = ({ className, service, isEmbed = false
   const [modelType, setModelType] = useState<'gltf' | 'glb' | 'obj' | 'server' | null>(null);
   const [serverModelFileType, setServerModelFileType] = useState<ModelFileType | null>(null);
   const [dpr, setDpr] = useState(2);
-  // const [performance, setPerformance] = useState<PerformanceMonitorApi>();
 
   // ローカルファイルの一時表示用状態
   const [localModel, setLocalModel] = useState<LocalModelData | null>(null);


### PR DESCRIPTION
🎯 **What:** Removed commented out code (`const [performance, setPerformance]`) from `src/features/heatmap/HeatmapViewer.tsx`.
💡 **Why:** To improve code maintainability and readability by cleaning up dead/unused code.
✅ **Verification:** Verified by code inspection and running `bun run lint`, `bun run format:check`, `bun run type` and `bun test`. No functional changes were made.
✨ **Result:** A cleaner component implementation.

---
*PR created automatically by Jules for task [8586155482426414893](https://jules.google.com/task/8586155482426414893) started by @matuyuhi*