### PR TITLE
🧹 Refactor long `useOnlineHeatmapDataService` function into separate testable hooks

### DIFF
--- a/src/utils/heatmap/HeatmapDataService.ts
+++ b/src/utils/heatmap/HeatmapDataService.ts
@@ -1,12 +1,16 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
+
+import { useHeatmapDataFetchers } from './hooks/useHeatmapDataFetchers';
+import { useHeatmapTask } from './hooks/useHeatmapTask';
 
 import type { ModelFileType } from '@src/features/heatmap/ModelLoader';
 import type { HeatmapStates } from '@src/modeles/heatmapView';
 import type { HeatmapTask, PositionEventLog } from '@src/modeles/heatmaptask';
 import type { Project } from '@src/modeles/project';
-import type { createClient } from '@src/modeles/qeury';
 import type { Session } from '@src/modeles/session';
+
+import { useAuth } from '@src/hooks/useAuth';
+import { useApiClient } from '@src/modeles/ApiClientContext';
 
 // セッション検索パラメータ
 export type SessionSearchParams = {
@@ -17,9 +21,6 @@ export type SessionSearchParams = {
   limit?: number;
   offset?: number;
 };
-
-import { useAuth } from '@src/hooks/useAuth';
-import { useApiClient } from '@src/modeles/ApiClientContext';
 
 // Field object log type (matches API response)
 export type FieldObjectLog = {
@@ -109,17 +110,6 @@ export const mockHeatmapDataService: HeatmapDataService = {
   getFieldObjectLogs: async () => [],
 };
 
-/**
- * ファイル形式文字列をModelFileTypeに変換
- */
-function parseModelFileType(fileTypeStr: string | null): ModelFileType | null {
-  if (!fileTypeStr) return null;
-  const lower = fileTypeStr.toLowerCase();
-  if (lower === 'obj' || lower === 'fbx' || lower === 'gltf' || lower === 'glb') {
-    return lower as ModelFileType;
-  }
-  return null;
-}
 // データ型定義
 export type OfflineHeatmapData = {
   task: HeatmapTask;
@@ -130,315 +120,19 @@ export type OfflineHeatmapData = {
   eventLogs: Record<string, PositionEventLog[]>;
 };
 
-// v0.1 API - normalized density (0-1 range)
-async function sessionCreateTask(apiClient: ReturnType<typeof createClient>, projectId: number, sessionId: number, stepSize: number, zVisible: boolean) {
-  return await apiClient.POST('/api/v0.1/heatmap/projects/{project_id}/play_session/{session_id}/tasks', {
-    params: {
-      path: {
-        project_id: projectId,
-        session_id: sessionId,
-      },
-    },
-    body: {
-      stepSize: stepSize,
-      zVisible: zVisible,
-    },
-  });
-}
-
-// v0.1 API - normalized density (0-1 range)
-async function projectCreateTask(apiClient: ReturnType<typeof createClient>, projectId: number, stepSize: number, zVisible: boolean, sessionIds?: number[]) {
-  return await apiClient.POST('/api/v0.1/heatmap/projects/{project_id}/tasks', {
-    params: {
-      path: {
-        project_id: projectId,
-      },
-    },
-    body: {
-      stepSize: stepSize,
-      zVisible: zVisible,
-      ...(sessionIds && sessionIds.length > 0 ? { sessionIds } : {}),
-    },
-  });
-}
-
 // 通常のオンライン環境用の実装
 export function useOnlineHeatmapDataService(projectId: number | undefined, initialTaskId: number | null, sessionHeatmap: boolean): HeatmapDataService {
-  const timer = useRef<NodeJS.Timeout>(undefined);
   const [taskId, setTaskId] = useState<number | null>(initialTaskId);
   const [sessionId, setSessionId] = useState<number | null>(null);
   const [sessionHeatmapIds, setSessionHeatmapIds] = useState<number[] | undefined>(undefined);
   const [stepSize] = useState<number>(50);
 
   const { isAuthorized, ready } = useAuth();
-  const queryClient = useQueryClient();
   const apiClient = useApiClient();
 
-  // プロジェクトデータを取得してis2Dフラグを取得
-  const { data: project } = useQuery({
-    queryKey: ['project', projectId],
-    queryFn: async () => {
-      if (!projectId) return null;
-      const res = await apiClient.GET('/api/v0/projects/{id}', {
-        params: { path: { id: projectId } },
-      });
-      return res.data ?? null;
-    },
-    staleTime: 1000 * 60 * 5, // 5分
-    enabled: !!projectId && isAuthorized,
-  });
+  const { task } = useHeatmapTask(apiClient, isAuthorized, projectId, sessionId, taskId, setTaskId, sessionHeatmap, sessionHeatmapIds, stepSize, initialTaskId);
 
-  // is2Dフラグに基づいてzVisibleを動的に決定（2Dの場合はzVisible=false）
-  const zVisible = !(project?.is2D ?? false);
-
-  const { data: createdTask } = useQuery({
-    queryKey: [projectId, sessionId, stepSize, zVisible, sessionHeatmap, sessionHeatmapIds, apiClient],
-    queryFn: async (): Promise<HeatmapTask | null> => {
-      if (!projectId) {
-        return null;
-      }
-
-      const { data, error } =
-        sessionHeatmap && sessionId && sessionId !== 0
-          ? await sessionCreateTask(apiClient, projectId, sessionId, stepSize, zVisible)
-          : await projectCreateTask(apiClient, projectId, stepSize, zVisible, sessionHeatmapIds);
-      if (error) throw error;
-      return data;
-    },
-    enabled: isAuthorized && projectId !== undefined && projectId !== 0 && initialTaskId === null,
-    retry: 3,
-  });
-
-  useEffect(() => {
-    if (!createdTask) return;
-    setTaskId(createdTask.taskId);
-  }, [createdTask]);
-
-  // v0.1 API - normalized density (0-1 range)
-  const { data: task } = useQuery({
-    queryKey: ['heatmap', isAuthorized, taskId],
-    queryFn: async (): Promise<HeatmapTask | null> => {
-      if (!taskId || isNaN(Number(taskId))) return null;
-      if (!isAuthorized) return null;
-      const { data, error } = await apiClient.GET('/api/v0.1/heatmap/tasks/{task_id}', {
-        params: { path: { task_id: Number(taskId) } },
-      });
-      if (error) throw error;
-      return data;
-    },
-    initialData: null,
-    enabled: taskId !== null && isAuthorized,
-    // apiClientは関数なので、依存配列に含めない（Contextから毎回取得されるため）
-  });
-
-  useEffect(() => {
-    if (!task) return;
-
-    if (task.status === 'pending' || task.status === 'processing') {
-      timer.current = setInterval(async () => {
-        await queryClient.invalidateQueries({ queryKey: ['heatmap'] });
-      }, 500);
-    }
-    return () => {
-      if (timer.current) {
-        clearInterval(timer.current);
-      }
-    };
-  }, [queryClient, task]);
-
-  const getMapList = useCallback(
-    async (activeOnly?: boolean) => {
-      try {
-        if (!projectId) {
-          return [];
-        }
-        const { data, error } = await apiClient.GET('/api/v0.1/projects/{project_id}/maps', {
-          params: {
-            path: {
-              project_id: Number(projectId),
-            },
-            query: {
-              activeOnly,
-            },
-          },
-        });
-        if (error) return [];
-        return data.maps || [];
-      } catch {
-        return [];
-      }
-    },
-    [projectId, apiClient],
-  );
-
-  const getMapContent = useCallback(
-    async (mapName: string): Promise<MapContentResult | null> => {
-      try {
-        if (!mapName || mapName === '') return null;
-        const { data, error, response } = await apiClient.GET('/api/v0/heatmap/map_data/{map_name}', {
-          params: {
-            path: {
-              map_name: mapName,
-            },
-          },
-          parseAs: 'arrayBuffer',
-        });
-        if (error) return null;
-
-        const fileTypeHeader = response.headers.get('X-Model-File-Type');
-        const fileType = parseModelFileType(fileTypeHeader);
-
-        return { data, fileType };
-      } catch {
-        return null;
-      }
-    },
-    [apiClient],
-  );
-
-  const getGeneralLogKeys = useCallback(async () => {
-    try {
-      if (projectId === undefined) return null;
-
-      const { data, error } = await apiClient.GET('/api/v0/general_log/position/keys', {
-        params: {
-          query: {
-            project_id: projectId,
-            session_id: sessionId ?? undefined,
-          },
-        },
-      });
-      if (error) return null;
-      return data.keys;
-    } catch {
-      return null;
-    }
-  }, [projectId, sessionId, apiClient]);
-
-  const getProjectLogs = useCallback(
-    async (logName: string) => {
-      if (!projectId) return null;
-      return await apiClient.GET('/api/v0/projects/{id}/general_log/position/{event_type}', {
-        params: {
-          path: {
-            id: projectId,
-            event_type: logName,
-          },
-          query: {
-            limit: 1000,
-            offset: 0,
-          },
-        },
-      });
-    },
-    [projectId, apiClient],
-  );
-
-  const getSessionLogs = useCallback(
-    async (logName: string) => {
-      if (!projectId || !sessionId) return null;
-      return await apiClient.GET('/api/v0/projects/{project_id}/play_session/{session_id}/general_log/position/{event_type}', {
-        params: {
-          path: {
-            project_id: projectId,
-            session_id: sessionId,
-            event_type: logName,
-          },
-          query: {
-            limit: 1000,
-            offset: 0,
-          },
-        },
-      });
-    },
-    [projectId, sessionId, apiClient],
-  );
-  const eventLogKey = (projectId: number | undefined, sessionId: number | null, logName: string) =>
-    ['eventLog', projectId ?? 0, sessionId ?? 0, logName] as const;
-
-  const getEventLog = useCallback(
-    async (logName: string): Promise<PositionEventLog[] | null> => {
-      const res = sessionId ? await getSessionLogs(logName) : await getProjectLogs(logName);
-      if (res?.error) throw res.error;
-      const data = res?.data ?? null;
-      if (data) {
-        queryClient.setQueryData(eventLogKey(projectId, sessionId, logName), data);
-      }
-      return data;
-    },
-    [projectId, sessionId, getSessionLogs, getProjectLogs, queryClient],
-  );
-
-  const getEventLogSnapshot = useCallback(
-    (logName: string): PositionEventLog[] | null => {
-      return (queryClient.getQueryData(eventLogKey(projectId, sessionId, logName)) as PositionEventLog[] | undefined) ?? null;
-    },
-    [projectId, sessionId, queryClient],
-  );
-
-  const getProject = useCallback(async () => {
-    if (!projectId) return null;
-    const res = await apiClient.GET('/api/v0/projects/{id}', {
-      params: { path: { id: projectId } },
-    });
-    return res.data ?? null;
-  }, [projectId, apiClient]);
-
-  const getSession = useCallback(async () => {
-    if (!projectId || !sessionId) return null;
-    const res = await apiClient.GET('/api/v0/projects/{project_id}/play_session/{session_id}', {
-      params: { path: { project_id: projectId, session_id: sessionId } },
-    });
-    return res.data ?? null;
-  }, [projectId, sessionId, apiClient]);
-
-  const getSessions = useCallback(
-    async (limit = 100, offset = 0) => {
-      if (!projectId) return [];
-      const res = await apiClient.GET('/api/v0/projects/{project_id}/play_session', {
-        params: { path: { project_id: projectId }, query: { limit, offset } },
-      });
-      return (res.data as Session[]) ?? [];
-    },
-    [projectId, apiClient],
-  );
-
-  const searchSessions = useCallback(
-    async (params: SessionSearchParams) => {
-      if (!projectId) return [];
-      const res = await apiClient.GET('/api/v0.1/projects/{project_id}/sessions/search', {
-        params: {
-          path: { project_id: projectId },
-          query: {
-            q: params.q,
-            device_id: params.deviceId,
-            platform: params.platform,
-            is_playing: params.isPlaying,
-            limit: params.limit ?? 100,
-            offset: params.offset ?? 0,
-          },
-        },
-      });
-      return res.data?.data ?? [];
-    },
-    [projectId, apiClient],
-  );
-
-  const getPlayers = useCallback(async () => {
-    if (!projectId || !sessionId) return [];
-    const res = await apiClient.GET('/api/v0/projects/{project_id}/play_session/{session_id}/player_position_log/{session_id}/players', {
-      params: { path: { project_id: projectId, session_id: sessionId } },
-    });
-    return (res.data as unknown as Player[]) ?? [];
-  }, [projectId, sessionId, apiClient]);
-
-  const getFieldObjectLogs = useCallback(async () => {
-    if (!projectId || !sessionId) return [];
-    const res = await apiClient.GET('/api/v0/projects/{project_id}/play_session/{session_id}/field_object_log', {
-      params: { path: { project_id: projectId, session_id: sessionId } },
-    });
-    return (res.data as unknown as FieldObjectLog[]) ?? [];
-  }, [projectId, sessionId, apiClient]);
+  const fetchers = useHeatmapDataFetchers(apiClient, projectId, sessionId);
 
   const loadTask = useCallback(
     (newTaskId: number) => {
@@ -451,23 +145,13 @@ export function useOnlineHeatmapDataService(projectId: number | undefined, initi
 
   return {
     isInitialized: isAuthorized && ready && projectId !== undefined,
-    getMapList,
-    getMapContent,
-    getGeneralLogKeys,
-    task: task || createdTask || undefined,
-    getEventLog,
-    getEventLogSnapshot,
+    ...fetchers,
+    task,
     projectId,
     sessionId,
     setSessionId,
     sessionHeatmapIds,
     setSessionHeatmapIds,
     loadTask,
-    getProject,
-    getSession,
-    getSessions,
-    searchSessions,
-    getPlayers,
-    getFieldObjectLogs,
   };
 }

--- a/src/utils/heatmap/hooks/useHeatmapDataFetchers.ts
+++ b/src/utils/heatmap/hooks/useHeatmapDataFetchers.ts
@@ -1,0 +1,232 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+import type { FieldObjectLog, MapContentResult, Player, SessionSearchParams } from '../HeatmapDataService';
+import type { ModelFileType } from '@src/features/heatmap/ModelLoader';
+import type { PositionEventLog } from '@src/modeles/heatmaptask';
+import type { createClient } from '@src/modeles/qeury';
+import type { Session } from '@src/modeles/session';
+
+/**
+ * ファイル形式文字列をModelFileTypeに変換
+ */
+function parseModelFileType(fileTypeStr: string | null): ModelFileType | null {
+  if (!fileTypeStr) return null;
+  const lower = fileTypeStr.toLowerCase();
+  if (lower === 'obj' || lower === 'fbx' || lower === 'gltf' || lower === 'glb') {
+    return lower as ModelFileType;
+  }
+  return null;
+}
+
+export function useHeatmapDataFetchers(apiClient: ReturnType<typeof createClient>, projectId: number | undefined, sessionId: number | null) {
+  const queryClient = useQueryClient();
+
+  const getMapList = useCallback(
+    async (activeOnly?: boolean) => {
+      try {
+        if (!projectId) {
+          return [];
+        }
+        const { data, error } = await apiClient.GET('/api/v0.1/projects/{project_id}/maps', {
+          params: {
+            path: {
+              project_id: Number(projectId),
+            },
+            query: {
+              activeOnly,
+            },
+          },
+        });
+        if (error) return [];
+        return data.maps || [];
+      } catch {
+        return [];
+      }
+    },
+    [projectId, apiClient],
+  );
+
+  const getMapContent = useCallback(
+    async (mapName: string): Promise<MapContentResult | null> => {
+      try {
+        if (!mapName || mapName === '') return null;
+        const { data, error, response } = await apiClient.GET('/api/v0/heatmap/map_data/{map_name}', {
+          params: {
+            path: {
+              map_name: mapName,
+            },
+          },
+          parseAs: 'arrayBuffer',
+        });
+        if (error) return null;
+
+        const fileTypeHeader = response.headers.get('X-Model-File-Type');
+        const fileType = parseModelFileType(fileTypeHeader);
+
+        return { data, fileType };
+      } catch {
+        return null;
+      }
+    },
+    [apiClient],
+  );
+
+  const getGeneralLogKeys = useCallback(async () => {
+    try {
+      if (projectId === undefined) return null;
+
+      const { data, error } = await apiClient.GET('/api/v0/general_log/position/keys', {
+        params: {
+          query: {
+            project_id: projectId,
+            session_id: sessionId ?? undefined,
+          },
+        },
+      });
+      if (error) return null;
+      return data.keys;
+    } catch {
+      return null;
+    }
+  }, [projectId, sessionId, apiClient]);
+
+  const getProjectLogs = useCallback(
+    async (logName: string) => {
+      if (!projectId) return null;
+      return await apiClient.GET('/api/v0/projects/{id}/general_log/position/{event_type}', {
+        params: {
+          path: {
+            id: projectId,
+            event_type: logName,
+          },
+          query: {
+            limit: 1000,
+            offset: 0,
+          },
+        },
+      });
+    },
+    [projectId, apiClient],
+  );
+
+  const getSessionLogs = useCallback(
+    async (logName: string) => {
+      if (!projectId || !sessionId) return null;
+      return await apiClient.GET('/api/v0/projects/{project_id}/play_session/{session_id}/general_log/position/{event_type}', {
+        params: {
+          path: {
+            project_id: projectId,
+            session_id: sessionId,
+            event_type: logName,
+          },
+          query: {
+            limit: 1000,
+            offset: 0,
+          },
+        },
+      });
+    },
+    [projectId, sessionId, apiClient],
+  );
+
+  const eventLogKey = useCallback((pId: number | undefined, sId: number | null, logName: string) => ['eventLog', pId ?? 0, sId ?? 0, logName] as const, []);
+
+  const getEventLog = useCallback(
+    async (logName: string): Promise<PositionEventLog[] | null> => {
+      const res = sessionId ? await getSessionLogs(logName) : await getProjectLogs(logName);
+      if (res?.error) throw res.error;
+      const data = res?.data ?? null;
+      if (data) {
+        queryClient.setQueryData(eventLogKey(projectId, sessionId, logName), data);
+      }
+      return data;
+    },
+    [projectId, sessionId, getSessionLogs, getProjectLogs, queryClient, eventLogKey],
+  );
+
+  const getEventLogSnapshot = useCallback(
+    (logName: string): PositionEventLog[] | null => {
+      return (queryClient.getQueryData(eventLogKey(projectId, sessionId, logName)) as PositionEventLog[] | undefined) ?? null;
+    },
+    [projectId, sessionId, queryClient, eventLogKey],
+  );
+
+  const getProject = useCallback(async () => {
+    if (!projectId) return null;
+    const res = await apiClient.GET('/api/v0/projects/{id}', {
+      params: { path: { id: projectId } },
+    });
+    return res.data ?? null;
+  }, [projectId, apiClient]);
+
+  const getSession = useCallback(async () => {
+    if (!projectId || !sessionId) return null;
+    const res = await apiClient.GET('/api/v0/projects/{project_id}/play_session/{session_id}', {
+      params: { path: { project_id: projectId, session_id: sessionId } },
+    });
+    return res.data ?? null;
+  }, [projectId, sessionId, apiClient]);
+
+  const getSessions = useCallback(
+    async (limit = 100, offset = 0) => {
+      if (!projectId) return [];
+      const res = await apiClient.GET('/api/v0/projects/{project_id}/play_session', {
+        params: { path: { project_id: projectId }, query: { limit, offset } },
+      });
+      return (res.data as Session[]) ?? [];
+    },
+    [projectId, apiClient],
+  );
+
+  const searchSessions = useCallback(
+    async (params: SessionSearchParams) => {
+      if (!projectId) return [];
+      const res = await apiClient.GET('/api/v0.1/projects/{project_id}/sessions/search', {
+        params: {
+          path: { project_id: projectId },
+          query: {
+            q: params.q,
+            device_id: params.deviceId,
+            platform: params.platform,
+            is_playing: params.isPlaying,
+            limit: params.limit ?? 100,
+            offset: params.offset ?? 0,
+          },
+        },
+      });
+      return res.data?.data ?? [];
+    },
+    [projectId, apiClient],
+  );
+
+  const getPlayers = useCallback(async () => {
+    if (!projectId || !sessionId) return [];
+    const res = await apiClient.GET('/api/v0/projects/{project_id}/play_session/{session_id}/player_position_log/{session_id}/players', {
+      params: { path: { project_id: projectId, session_id: sessionId } },
+    });
+    return (res.data as unknown as Player[]) ?? [];
+  }, [projectId, sessionId, apiClient]);
+
+  const getFieldObjectLogs = useCallback(async () => {
+    if (!projectId || !sessionId) return [];
+    const res = await apiClient.GET('/api/v0/projects/{project_id}/play_session/{session_id}/field_object_log', {
+      params: { path: { project_id: projectId, session_id: sessionId } },
+    });
+    return (res.data as unknown as FieldObjectLog[]) ?? [];
+  }, [projectId, sessionId, apiClient]);
+
+  return {
+    getMapList,
+    getMapContent,
+    getGeneralLogKeys,
+    getEventLog,
+    getEventLogSnapshot,
+    getProject,
+    getSession,
+    getSessions,
+    searchSessions,
+    getPlayers,
+    getFieldObjectLogs,
+  };
+}

--- a/src/utils/heatmap/hooks/useHeatmapTask.ts
+++ b/src/utils/heatmap/hooks/useHeatmapTask.ts
@@ -1,0 +1,129 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
+
+import type { HeatmapTask } from '@src/modeles/heatmaptask';
+import type { createClient } from '@src/modeles/qeury';
+
+// v0.1 API - normalized density (0-1 range)
+async function sessionCreateTask(apiClient: ReturnType<typeof createClient>, projectId: number, sessionId: number, stepSize: number, zVisible: boolean) {
+  return await apiClient.POST('/api/v0.1/heatmap/projects/{project_id}/play_session/{session_id}/tasks', {
+    params: {
+      path: {
+        project_id: projectId,
+        session_id: sessionId,
+      },
+    },
+    body: {
+      stepSize: stepSize,
+      zVisible: zVisible,
+    },
+  });
+}
+
+// v0.1 API - normalized density (0-1 range)
+async function projectCreateTask(apiClient: ReturnType<typeof createClient>, projectId: number, stepSize: number, zVisible: boolean, sessionIds?: number[]) {
+  return await apiClient.POST('/api/v0.1/heatmap/projects/{project_id}/tasks', {
+    params: {
+      path: {
+        project_id: projectId,
+      },
+    },
+    body: {
+      stepSize: stepSize,
+      zVisible: zVisible,
+      ...(sessionIds && sessionIds.length > 0 ? { sessionIds } : {}),
+    },
+  });
+}
+
+export function useHeatmapTask(
+  apiClient: ReturnType<typeof createClient>,
+  isAuthorized: boolean,
+  projectId: number | undefined,
+  sessionId: number | null,
+  taskId: number | null,
+  setTaskId: (taskId: number | null) => void,
+  sessionHeatmap: boolean,
+  sessionHeatmapIds: number[] | undefined,
+  stepSize: number,
+  initialTaskId: number | null,
+) {
+  const timer = useRef<NodeJS.Timeout>(undefined);
+  const queryClient = useQueryClient();
+
+  // プロジェクトデータを取得してis2Dフラグを取得
+  const { data: project } = useQuery({
+    queryKey: ['project', projectId],
+    queryFn: async () => {
+      if (!projectId) return null;
+      const res = await apiClient.GET('/api/v0/projects/{id}', {
+        params: { path: { id: projectId } },
+      });
+      return res.data ?? null;
+    },
+    staleTime: 1000 * 60 * 5, // 5分
+    enabled: !!projectId && isAuthorized,
+  });
+
+  // is2Dフラグに基づいてzVisibleを動的に決定（2Dの場合はzVisible=false）
+  const zVisible = !(project?.is2D ?? false);
+
+  const { data: createdTask } = useQuery({
+    queryKey: [projectId, sessionId, stepSize, zVisible, sessionHeatmap, sessionHeatmapIds, apiClient],
+    queryFn: async (): Promise<HeatmapTask | null> => {
+      if (!projectId) {
+        return null;
+      }
+
+      const { data, error } =
+        sessionHeatmap && sessionId && sessionId !== 0
+          ? await sessionCreateTask(apiClient, projectId, sessionId, stepSize, zVisible)
+          : await projectCreateTask(apiClient, projectId, stepSize, zVisible, sessionHeatmapIds);
+      if (error) throw error;
+      return data;
+    },
+    enabled: isAuthorized && projectId !== undefined && projectId !== 0 && initialTaskId === null,
+    retry: 3,
+  });
+
+  useEffect(() => {
+    if (!createdTask) return;
+    setTaskId(createdTask.taskId);
+  }, [createdTask, setTaskId]);
+
+  // v0.1 API - normalized density (0-1 range)
+  const { data: task } = useQuery({
+    queryKey: ['heatmap', isAuthorized, taskId],
+    queryFn: async (): Promise<HeatmapTask | null> => {
+      if (!taskId || isNaN(Number(taskId))) return null;
+      if (!isAuthorized) return null;
+      const { data, error } = await apiClient.GET('/api/v0.1/heatmap/tasks/{task_id}', {
+        params: { path: { task_id: Number(taskId) } },
+      });
+      if (error) throw error;
+      return data;
+    },
+    initialData: null,
+    enabled: taskId !== null && isAuthorized,
+    // apiClientは関数なので、依存配列に含めない（Contextから毎回取得されるため）
+  });
+
+  useEffect(() => {
+    if (!task) return;
+
+    if (task.status === 'pending' || task.status === 'processing') {
+      timer.current = setInterval(async () => {
+        await queryClient.invalidateQueries({ queryKey: ['heatmap'] });
+      }, 500);
+    }
+    return () => {
+      if (timer.current) {
+        clearInterval(timer.current);
+      }
+    };
+  }, [queryClient, task]);
+
+  return {
+    task: task || createdTask || undefined,
+  };
+}


### PR DESCRIPTION
🎯 **What:** Extracted task management and data fetching functionality from `useOnlineHeatmapDataService` into two new dedicated hooks (`useHeatmapTask` and `useHeatmapDataFetchers`).
💡 **Why:** `useOnlineHeatmapDataService` had grown too large (~400 lines) combining various domain logics making it complex to test and maintain. By extracting domain-specific hook units, the complexity is significantly lowered, facilitating easier testing and clearer intent.
✅ **Verification:** Ran type checking (`bun run type`), tests (`bun test`), linting (`bun run lint`), and formatting (`bun run format:check`). Manual verification of file contents to ensure all logic and dependency mappings correctly correspond.
✨ **Result:** `useOnlineHeatmapDataService` is reduced to a concise compositing function, acting purely as a facade over the newly refactored data fetchers and task manager. Maintainability is drastically improved.

---
*PR created automatically by Jules for task [11941962617335524993](https://jules.google.com/task/11941962617335524993) started by @matuyuhi*