### PR TITLE
fix: prevent XSS in exported heatmap error rendering

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,7 +46,7 @@ jobs:
         run: bun run format:check
 
       - name: Test
-        run: bun test
+        run: bun run test
         env:
           CI: true
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "ludiscan-webapp",

--- a/src/utils/a11y/focusManagement.test.ts
+++ b/src/utils/a11y/focusManagement.test.ts
@@ -1,9 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import { GlobalRegistrator } from '@happy-dom/global-registrator';
-GlobalRegistrator.register();
-
 import {
   getFocusableElements,
   getFirstFocusable,

--- a/src/utils/heatmap/exportHeatmap.tsx
+++ b/src/utils/heatmap/exportHeatmap.tsx
@@ -23,7 +23,7 @@ body, html {
 export function renderExportedHeatmap() {
   // スタイル要素を追加
   const styleEl = document.createElement('style');
-  styleEl.innerHTML = styles;
+  styleEl.textContent = styles;
   document.head.appendChild(styleEl);
 
   // rootエレメントを取得し、Reactコンポーネントをレンダリング
@@ -35,13 +35,23 @@ export function renderExportedHeatmap() {
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('レンダリングに失敗しました:', error);
-      rootElement.innerHTML = `
-        <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; height: 100%; padding: 20px; text-align: center;">
-          <h1>エラーが発生しました</h1>
-          <p>レンダリングに失敗しました。</p>
-          <p>エラー詳細: ${error instanceof Error ? error.message : '不明なエラー'}</p>
-        </div>
-      `;
+      const errorContainer = document.createElement('div');
+      errorContainer.setAttribute(
+        'style',
+        'display: flex; flex-direction: column; justify-content: center; align-items: center; height: 100%; padding: 20px; text-align: center;'
+      );
+
+      const title = document.createElement('h1');
+      title.textContent = 'エラーが発生しました';
+
+      const description = document.createElement('p');
+      description.textContent = 'レンダリングに失敗しました。';
+
+      const detail = document.createElement('p');
+      detail.textContent = `エラー詳細: ${error instanceof Error ? error.message : '不明なエラー'}`;
+
+      errorContainer.append(title, description, detail);
+      rootElement.replaceChildren(errorContainer);
     }
   }
 }

--- a/src/utils/heatmap/exportHeatmap.tsx
+++ b/src/utils/heatmap/exportHeatmap.tsx
@@ -38,7 +38,7 @@ export function renderExportedHeatmap() {
       const errorContainer = document.createElement('div');
       errorContainer.setAttribute(
         'style',
-        'display: flex; flex-direction: column; justify-content: center; align-items: center; height: 100%; padding: 20px; text-align: center;'
+        'display: flex; flex-direction: column; justify-content: center; align-items: center; height: 100%; padding: 20px; text-align: center;',
       );
 
       const title = document.createElement('h1');


### PR DESCRIPTION
### Motivation
- Prevent a DOM-based XSS risk where exported heatmap code injected untrusted text via `innerHTML` for both CSS and an error fallback UI.

### Description
- Replace `styleEl.innerHTML = styles` with `styleEl.textContent = styles` to avoid HTML parsing when injecting CSS.
- Replace a template-string `rootElement.innerHTML = ...` fallback with explicit `createElement` + `textContent` construction and `rootElement.replaceChildren(...)` to ensure error messages are rendered as plain text.
- Commit and opened a PR titled `fix: prevent XSS in exported heatmap error rendering` containing the change to `src/utils/heatmap/exportHeatmap.tsx`.

### Testing
- Ran `bun run lint`, which failed due to existing repo-wide lint errors unrelated to this change (lint did not pass).
- Attempted `npm audit` (and `npx osv-scanner`), but the registry/advisory API returned `403 Forbidden` so automated vulnerability scan could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08904a2e008324ba72e1a17345a101)