### PR TITLE
feat(profile): add forgot-password link to password change section

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -103,6 +103,7 @@ export const en = {
       submit: 'Update Password',
       hint: 'New password must be at least 8 characters.',
       success: 'Password updated',
+      forgotPassword: 'Forgot your current password? Send a reset link instead.',
       errorRequired: 'Please fill in all fields',
       errorMismatch: 'New passwords do not match',
       errorTooShort: 'New password must be at least 8 characters',

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -103,6 +103,7 @@ export const ja = {
       submit: 'パスワードを更新',
       hint: '新しいパスワードは8文字以上で入力してください。',
       success: 'パスワードを更新しました',
+      forgotPassword: '現在のパスワードを忘れた場合はこちら（再設定リンクを送ります）',
       errorRequired: 'すべての項目を入力してください',
       errorMismatch: '新しいパスワードが一致しません',
       errorTooShort: '新しいパスワードは8文字以上で入力してください',

--- a/src/pages/profile/index.page.tsx
+++ b/src/pages/profile/index.page.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -312,14 +313,19 @@ const Component: FC<ProfilePageProps> = ({ className }) => {
           >
             <FlexColumn gap={12}>
               {!isInitialSetup && (
-                <OutlinedTextField
-                  label={t('profile.passwordUpdate.currentPassword')}
-                  value={currentPassword}
-                  onChange={setCurrentPassword}
-                  type='password'
-                  fontSize={theme.typography.fontSize.base}
-                  disabled={isUpdatingPassword}
-                />
+                <>
+                  <OutlinedTextField
+                    label={t('profile.passwordUpdate.currentPassword')}
+                    value={currentPassword}
+                    onChange={setCurrentPassword}
+                    type='password'
+                    fontSize={theme.typography.fontSize.base}
+                    disabled={isUpdatingPassword}
+                  />
+                  <Link href='/password-reset/request' className={`${className}__forgotPassword`}>
+                    {t('profile.passwordUpdate.forgotPassword')}
+                  </Link>
+                </>
               )}
               <OutlinedTextField
                 label={t('profile.passwordUpdate.newPassword')}
@@ -486,6 +492,18 @@ const ProfilePage = styled(Component)`
   &__submitRow {
     justify-content: flex-end;
     margin-top: ${({ theme }) => theme.spacing.sm};
+  }
+
+  &__forgotPassword {
+    align-self: flex-start;
+    font-size: ${({ theme }) => theme.typography.fontSize.sm};
+    color: ${({ theme }) => theme.colors.text.secondary};
+    text-decoration: underline;
+    text-underline-offset: 2px;
+
+    &:hover {
+      color: ${({ theme }) => theme.colors.text.primary};
+    }
   }
 
   &__centerContent {


### PR DESCRIPTION
## Summary

- profile ページのパスワード変更フォームで「現在のパスワード」欄の真下に「現在のパスワードを忘れた場合はこちら（再設定リンクを送ります）」リンクを追加。クリックで \`/password-reset/request\` へ遷移。
- リンクは「現在のパスワード」欄が表示されているとき（= 通常のパスワード変更モード）のみ出す。OAuth-only の初回設定モード (\`isInitialSetup === true\`) では現在のパスワード自体が不要なのでリンクも非表示。
- ロケール \`profile.passwordUpdate.forgotPassword\` を ja/en に追加。

## Why

これまで profile ページでパスワード変更を行うには「現在のパスワード」が必須で、それを忘れたユーザーには逃げ道がなかった。先に追加した \`/password-reset/request\` のフローへ動線を引いておく。

## Test plan

- [x] \`bun run type\` (no errors)
- [x] \`bun run lint:eslint\` (no errors)
- [x] \`bun run format:check\` (no issues)
- [ ] パスワード設定済みユーザーで /profile を開き、パスワード変更セクションにリンクが出ることを確認
- [ ] OAuth-only ユーザー（\`hasPassword === false\`）で /profile を開き、リンクが出ないことを確認
- [ ] リンククリックで \`/password-reset/request\` に遷移できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)