### PR TITLE
feat(login): honor ?returnTo= and route back-to-sign-in flows home

### DIFF
--- a/src/pages/login/index.page.tsx
+++ b/src/pages/login/index.page.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useMemo, useState } from 'react';
 
 import type { FC } from 'react';
@@ -29,8 +29,21 @@ export type LoginPageProps = {
   className?: string | undefined;
 };
 
+/**
+ * Accepts only same-origin relative paths to avoid open-redirect via ?returnTo=.
+ * Allows "/foo" / "/foo?x=1" / "/foo#bar" but rejects "//evil.com" and absolute URLs.
+ */
+const sanitizeReturnTo = (raw: string | null | undefined): string | null => {
+  if (!raw) return null;
+  if (!raw.startsWith('/')) return null;
+  if (raw.startsWith('//')) return null;
+  return raw;
+};
+
 const Content: FC<LoginPageProps> = ({ className }) => {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const returnTo = sanitizeReturnTo(searchParams?.get('returnTo'));
   const isDesktop = useIsDesktop();
   const { theme } = useSharedTheme();
   const { t } = useLocale();
@@ -38,8 +51,12 @@ const Content: FC<LoginPageProps> = ({ className }) => {
   const [password, setPassword] = useState('');
   const { showToast } = useToast();
   const onClose = useCallback(() => {
+    if (returnTo) {
+      router.replace(returnTo);
+      return;
+    }
     router.back();
-  }, [router]);
+  }, [returnTo, router]);
   const handleInputEmail = useCallback((e: string) => {
     setEmail(e);
   }, []);

--- a/src/pages/password-reset/confirm/index.page.tsx
+++ b/src/pages/password-reset/confirm/index.page.tsx
@@ -56,7 +56,7 @@ const Content: FC<PasswordResetConfirmPageProps> = ({ className }) => {
     onSuccess: () => {
       setDone(true);
       showToast(t('passwordReset.confirm.success'), 3, 'success');
-      setTimeout(() => router.replace('/login'), 1500);
+      setTimeout(() => router.replace('/login?returnTo=/'), 1500);
     },
     onError: (error: Error) => {
       showToast(error.message, 3, 'error');
@@ -141,7 +141,7 @@ const Content: FC<PasswordResetConfirmPageProps> = ({ className }) => {
                 <Text text={isPending ? t('passwordReset.confirm.submitting') : t('passwordReset.confirm.submit')} />
               </Button>
             )}
-            <Link href='/login' className={`${className}__back`}>
+            <Link href='/login?returnTo=/' className={`${className}__back`}>
               {t('passwordReset.confirm.backToLogin')}
             </Link>
           </InlineFlexColumn>

--- a/src/pages/password-reset/request/index.page.tsx
+++ b/src/pages/password-reset/request/index.page.tsx
@@ -105,7 +105,7 @@ const Content: FC<PasswordResetRequestPageProps> = ({ className }) => {
                 <Text text={isPending ? t('passwordReset.request.sending') : t('passwordReset.request.submit')} />
               </Button>
             )}
-            <Link href='/login' className={`${className}__back`}>
+            <Link href='/login?returnTo=/' className={`${className}__back`}>
               {t('passwordReset.request.backToLogin')}
             </Link>
           </InlineFlexColumn>


### PR DESCRIPTION
## Summary

- \`/login\` が \`?returnTo=\` クエリパラメータを受け取り、ログイン成功時にそのパスへ遷移するようにした。
- 受け入れるのは「\`/\` で始まる かつ \`//\` で始まらない」相対パスのみ。絶対 URL や \`//evil.example.com\` のような protocol-relative はスキップする（open-redirect 対策）。
- \`returnTo\` が無い場合は既存の \`router.back()\` 挙動を維持する（他経路の auth ガード経由で \`/login\` に飛ばされたケースなどを壊さない）。
- \`/password-reset/request\` と \`/password-reset/confirm\` の「Back to sign in」リンク、および confirm 成功後の自動遷移を全て \`/login?returnTo=/\` に変更。

## Why

\`/password-reset/request\` から「Back to sign in」 → \`/login\` でログインすると、ログイン成功時の \`router.back()\` で履歴を1つ戻り、\`/password-reset/request\` に戻ってしまっていた。本来はホームに戻したい。

## Test plan

- [x] \`bun run type\`
- [x] \`bun run lint:eslint\`
- [x] \`bun run format:check\`
- [ ] \`/password-reset/request\` → 「Back to sign in」 → ログイン → \`/\` に着地することを確認
- [ ] \`/password-reset/confirm?token=...\` → 「Back to sign in」 → ログイン → \`/\` に着地することを確認
- [ ] confirm でパスワード設定成功後、\`/\` に着地することを確認
- [ ] 通常の \`/login\` 直接アクセスでは \`returnTo\` 無しなので従来通り \`router.back()\` する
- [ ] \`/login?returnTo=//evil.example.com\` や \`/login?returnTo=https://evil.example.com\` ではログイン後に \`router.back()\` にフォールバック（open-redirect しない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)