### PR TITLE
perf(heatmap): skip refetch of completed heatmap tasks via staleTime

### DIFF
--- a/src/utils/heatmap/EmbedHeatmapDataService.ts
+++ b/src/utils/heatmap/EmbedHeatmapDataService.ts
@@ -109,6 +109,8 @@ export function useEmbedHeatmapDataService(projectId: number | undefined, sessio
     },
     initialData: null,
     enabled: taskId !== null && !!apiClient,
+    // 完了タスクは task_id 単位で不変なので再fetchしない（pending/processing中は下のポーリングで更新）
+    staleTime: (query) => (query.state.data?.status === 'completed' ? Infinity : 0),
   });
 
   useEffect(() => {

--- a/src/utils/heatmap/HeatmapDataService.ts
+++ b/src/utils/heatmap/HeatmapDataService.ts
@@ -228,6 +228,8 @@ export function useOnlineHeatmapDataService(projectId: number | undefined, initi
     },
     initialData: null,
     enabled: taskId !== null && isAuthorized,
+    // 完了タスクは task_id 単位で不変なので再fetchしない（pending/processing中は下のポーリングで更新）
+    staleTime: (query) => (query.state.data?.status === 'completed' ? Infinity : 0),
     // apiClientは関数なので、依存配列に含めない（Contextから毎回取得されるため）
   });
 


### PR DESCRIPTION
## 背景
ヒートマップタスク取得 `useQuery` は `staleTime` 未設定（=毎回 stale）で、完了後も再マウント/フォーカスで再 fetch が発生していた。完了済みタスクは `task_id` 単位で不変なので、再取得は不要。

## 変更内容
- `HeatmapDataService.ts` / `EmbedHeatmapDataService.ts` のタスク取得 `useQuery` に関数型 `staleTime` を追加:
  ```ts
  staleTime: (query) => (query.state.data?.status === 'completed' ? Infinity : 0),
  ```
  - `completed` → `Infinity`（再 fetch しない）
  - それ以外 → `0`（従来どおり。pending/processing 中の 500ms ポーリングも維持）

## 効果
バックエンド側 PR（`private, max-age` + ETag/304）と組み合わせ、重い GET の再取得・再転送・DBクエリを 2 層で削減:
- フロント: そもそも再 fetch を発生させない（完了タスク）
- バック: 再 fetch 時も 304 で本文転送を省略

## 関連バック PR
ludiscan-api-v0: `perf(cache): add private Cache-Control + ETag/304 to heavy GET endpoints`（#217）

🤖 Generated with [Claude Code](https://claude.com/claude-code)