### PR TITLE
perf(query): set QueryClient defaultOptions to reduce wasteful refetch

### DIFF
--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -20,6 +20,7 @@ import { LocaleProvider } from '@src/contexts/LocaleContext';
 import { useIsDesktop } from '@src/hooks/useIsDesktop';
 import { SharedThemeProvider } from '@src/hooks/useSharedTheme';
 import { SidebarProvider } from '@src/hooks/useSidebar';
+import { DefaultStaleTime } from '@src/modeles/qeury';
 import { store } from '@src/store';
 import { dimensions, zIndexes } from '@src/styles/style';
 
@@ -97,7 +98,21 @@ export default function App({ Component, pageProps }: AppProps) {
   const isDesktop = useIsDesktop();
   const [isPageLoading, setIsPageLoading] = useState(false);
   ReactModal.setAppElement('#__next');
-  const queryClient = useMemo(() => new QueryClient(), []);
+  const queryClient = useMemo(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            // 既定では毎回 stale + フォーカス毎 refetch で無駄なリクエストが出るため明示設定
+            staleTime: DefaultStaleTime, // 15分
+            gcTime: 1000 * 60 * 30, // 30分（既定5分だとキャッシュがすぐ破棄される）
+            refetchOnWindowFocus: false, // フォーカス毎の全クエリ refetch を抑制
+            retry: 1, // 失敗時のリトライを 3→1 に抑え、バックエンド負荷を軽減
+          },
+        },
+      }),
+    [],
+  );
   const storeRef = useRef<AppStore>(undefined);
   if (!storeRef.current) {
     storeRef.current = store();


### PR DESCRIPTION
## 背景
`_app.page.tsx` の `new QueryClient()` は `defaultOptions` 未設定で、TanStack Query 既定の `staleTime: 0` + `refetchOnWindowFocus: true` で動作していた。結果、ウィンドウフォーカスのたびに全アクティブクエリが refetch される。webapp はバックエンド直アクセス構成のため、これがそのままバックエンドへの無駄なリクエスト＝負荷・コストに直結していた。

## 変更内容
`QueryClient` に `defaultOptions.queries` を設定:
- `staleTime: 15分`（既存 `DefaultStaleTime` と統一）
- `gcTime: 30分`（既定5分から延長してキャッシュ保持を改善）
- `refetchOnWindowFocus: false`（フォーカス毎の全クエリ refetch を抑制）
- `retry: 1`（3→1。失敗時のリトライ回数を抑えバックエンド負荷を軽減）

※ ポーリング系（AISummary / RouteCoach 等の `refetchInterval`）は `refetchOnWindowFocus` とは独立なので影響なし。

## 効果
- フォーカス復帰時の不要な一斉 refetch を停止 → バックエンド負荷・転送量削減、UX 改善（ちらつき防止）。
- バック側の圧縮 PR・キャッシュ PR と相乗。

## 確認
- `npm run type` 成功 / ESLint クリーン。

## 関連
- バック側 PR: gzip/brotli 圧縮（ludiscan-api-v0 #218）、Cache-Control/ETag/304（#217 マージ済）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)