### PR TITLE
🔒 Security Fix: Remove deprecated and vulnerable `localStorage` token functions

### DIFF
--- a/src/utils/localstrage.test.ts
+++ b/src/utils/localstrage.test.ts
@@ -3,8 +3,6 @@ import type { User } from '@src/modeles/user';
 
 import { initializeValues, type HeatmapDataState } from '@src/modeles/heatmapView';
 import {
-  saveToken,
-  getToken,
   saveUser,
   getUser,
   saveCanvasValues,
@@ -60,32 +58,6 @@ describe('localstrage', () => {
   beforeEach(() => {
     mockStorage = {};
     jest.clearAllMocks();
-  });
-
-  describe('Token functions', () => {
-    describe('saveToken', () => {
-      test('should save a token to localStorage', () => {
-        saveToken('my-token');
-        expect(localStorage.setItem).toHaveBeenCalledWith(STORAGE_KEY, JSON.stringify({ token: 'my-token' }));
-      });
-
-      test('should preserve existing data when saving a token', () => {
-        mockStorage[STORAGE_KEY] = JSON.stringify({ otherData: 'value' });
-        saveToken('my-token');
-        expect(localStorage.setItem).toHaveBeenCalledWith(STORAGE_KEY, JSON.stringify({ otherData: 'value', token: 'my-token' }));
-      });
-    });
-
-    describe('getToken', () => {
-      test('should return null when there is no token in localStorage', () => {
-        expect(getToken()).toBeNull();
-      });
-
-      test('should retrieve the token from localStorage', () => {
-        mockStorage[STORAGE_KEY] = JSON.stringify({ token: 'my-token' });
-        expect(getToken()).toBe('my-token');
-      });
-    });
   });
 
   describe('User functions', () => {

--- a/src/utils/localstrage.ts
+++ b/src/utils/localstrage.ts
@@ -6,46 +6,6 @@ import { initializeValues } from '@src/modeles/heatmapView';
 
 const STORAGE_KEY = 'ludiscan';
 
-/**
- * @deprecated Authentication tokens are now stored in httpOnly cookies for security.
- * This function is kept for backward compatibility but should not be used for new code.
- * Use the authentication API routes (/api/auth/login) instead.
- *
- * Security note: Storing tokens in localStorage is vulnerable to XSS attacks.
- * httpOnly cookies provide better protection.
- */
-export function saveToken(token: string): void {
-  // SSR safety check - localStorage is only available in browser
-  if (typeof window === 'undefined') return;
-
-  const storage = localStorage.getItem(STORAGE_KEY);
-  if (storage) {
-    const data = JSON.parse(storage);
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...data, token }));
-  } else {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ token }));
-  }
-}
-
-/**
- * @deprecated Authentication tokens are now stored in httpOnly cookies for security.
- * This function is kept for backward compatibility but should not be used for new code.
- * Use the authentication API routes (/api/auth/session) instead.
- *
- * Security note: Storing tokens in localStorage is vulnerable to XSS attacks.
- * httpOnly cookies provide better protection.
- */
-export function getToken(): string | null {
-  // SSR safety check - localStorage is only available in browser
-  if (typeof window === 'undefined') return null;
-
-  const storage = localStorage.getItem(STORAGE_KEY);
-  if (storage) {
-    return JSON.parse(storage).token || null;
-  }
-  return null;
-}
-
 export function saveUser(user: User | null): void {
   // SSR safety check - localStorage is only available in browser
   if (typeof window === 'undefined') return;


### PR DESCRIPTION
🎯 **What:** The `saveToken` and `getToken` functions have been completely removed from `src/utils/localstrage.ts`, along with their corresponding unit tests.

⚠️ **Risk:** The previous implementation stored authentication tokens in `localStorage`. This is a significant security vulnerability, as `localStorage` is fully accessible to any JavaScript running on the page, making the tokens susceptible to Cross-Site Scripting (XSS) attacks. If an attacker successfully executes a malicious script, they could easily extract these tokens and impersonate the user.

🛡️ **Solution:** The functions were entirely deleted rather than replaced with empty stubs (no-ops). This leverages the TypeScript compiler to ensure that any remaining legacy call-sites will fail to build, forcing a hard migration away from this insecure practice. Authentication tokens should now exclusively be handled via secure, `httpOnly` cookies as noted in the previous deprecation warnings. All unit tests, linting, and formatting checks pass with this removal.

---
*PR created automatically by Jules for task [8516015034921853680](https://jules.google.com/task/8516015034921853680) started by @Matuyuhi*