### PR TITLE
🧹 Fix explicit 'any' casting in FormFieldWithError

### DIFF
--- a/src/component/molecules/FormFieldWithError.tsx
+++ b/src/component/molecules/FormFieldWithError.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { cloneElement, isValidElement, useId } from 'react';
+import React, { cloneElement, isValidElement, useId } from 'react';
 
 import type { FC, ReactElement } from 'react';
 
@@ -186,8 +186,7 @@ export const FormFieldWithError: FC<FormFieldWithErrorProps> = ({ label, fieldId
         'aria-describedby': describedBy || undefined,
         'aria-invalid': error ? 'true' : 'false',
         'aria-required': required ? 'true' : undefined,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any)
+      } as React.HTMLAttributes<HTMLElement>)
     : children;
 
   return (


### PR DESCRIPTION
🎯 **What:** Removed explicit `any` casting in `src/component/molecules/FormFieldWithError.tsx` and replaced it with `React.HTMLAttributes<HTMLElement>`.
💡 **Why:** This improves maintainability and ensures type safety by properly mapping standard ARIA and HTML attributes to the expected React types, resolving the `typescript-eslint/no-explicit-any` ESLint warning.
✅ **Verification:** Verified by running `bun run type` to ensure no TypeScript compilation errors, `bun run lint` to confirm ESLint and Stylelint pass successfully, and `bun run test` to verify no regressions were introduced.
✨ **Result:** The codebase is cleaner and adheres to strict typing rules.

---
*PR created automatically by Jules for task [14160492151393727565](https://jules.google.com/task/14160492151393727565) started by @Matuyuhi*