### PR TITLE
🧹 Fix unresolved GTM ID in environment configuration

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 const envSchema = z.object({
   NEXT_PUBLIC_HOSTNAME: z.string().default('http://localhost:5173'),
   NEXT_PUBLIC_API_BASE_URL: z.string().default('http://localhost:3211'),
-  NEXT_PUBLIC_GTM_ID: z.string().default('GTM-XXXXXXX'),
+  NEXT_PUBLIC_GTM_ID: z.string().optional(),
   // Server-side only env vars
   SESSION_SECRET: z.string().optional(),
   CSRF_SECRET: z.string().optional(),
@@ -20,7 +20,7 @@ const envSchema = z.object({
 const runtimeSchema = z.object({
   NEXT_PUBLIC_HOSTNAME: z.string().url('Invalid HOSTNAME URL'),
   NEXT_PUBLIC_API_BASE_URL: z.string().url('Invalid API_BASE_URL'),
-  NEXT_PUBLIC_GTM_ID: z.string().min(1, 'GTM_ID is required'),
+  NEXT_PUBLIC_GTM_ID: z.string().min(1, 'GTM_ID is required').optional(),
   SESSION_SECRET: z.string().min(32, 'SESSION_SECRET must be at least 32 characters').optional(),
   CSRF_SECRET: z.string().min(32, 'CSRF_SECRET must be at least 32 characters').optional(),
 });

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -172,7 +172,7 @@ export default function App({ Component, pageProps }: AppProps) {
           </QueryClientProvider>
         </LocaleProvider>
       </Provider>
-      <GoogleTagManager gtmId={env.NEXT_PUBLIC_GTM_ID} />
+      {env.NEXT_PUBLIC_GTM_ID && <GoogleTagManager gtmId={env.NEXT_PUBLIC_GTM_ID} />}
     </>
   );
 }


### PR DESCRIPTION
🎯 **What:** Removed the hardcoded placeholder `'GTM-XXXXXXX'` from `envSchema` and made `NEXT_PUBLIC_GTM_ID` optional. Updated the `<GoogleTagManager />` component in `_app.page.tsx` to conditionally render only if the ID is present.
💡 **Why:** Having a dummy default value in the configuration is dangerous as it could be inadvertently deployed to production, leading to confusing GTM behavior or tracking errors. Making it optional enforces proper configuration while avoiding invalid defaults.
✅ **Verification:** Ran `npm run test` which passed, and successfully executed ESLint and Stylelint via `bun run lint:eslint && bun run lint:stylelint`. Verified the code changes align with Next.js environment variable usage and Google Tag Manager expectations.
✨ **Result:** The codebase is safer by rejecting invalid GTM configurations, improving maintainability and reducing the likelihood of runtime tracking errors.

---
*PR created automatically by Jules for task [7790684910788693403](https://jules.google.com/task/7790684910788693403) started by @Matuyuhi*