### PR TITLE
🧪 [test] add unit tests for useRouteCoach hooks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "ludiscan-webapp",
@@ -51,6 +50,8 @@
         "@svgr/webpack": "^8.1.0",
         "@swc/core": "^1.15.8",
         "@tanstack/eslint-plugin-query": "^5.91.2",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/cookie": "^1.0.0",
         "@types/file-saver": "^2.0.7",
         "@types/jest": "^29.5.14",
@@ -812,7 +813,9 @@
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 
-    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.8.0", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ=="],
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
 
     "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
 
@@ -3138,6 +3141,8 @@
 
     "@storybook/expect/@types/jest": ["@types/jest@28.1.3", "", { "dependencies": { "jest-matcher-utils": "^28.0.0", "pretty-format": "^28.0.0" } }, "sha512-Tsbjk8Y2hkBaY/gJsataeb4q9Mubw9EOz7+4RjPkzD5KjTvHHs7cpws22InaoXxAVAhF5HfFbzJjo6oKWqSZLw=="],
 
+    "@storybook/jest/@testing-library/jest-dom": ["@testing-library/jest-dom@6.8.0", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ=="],
+
     "@storybook/jest/@types/jest": ["@types/jest@28.1.3", "", { "dependencies": { "jest-matcher-utils": "^28.0.0", "pretty-format": "^28.0.0" } }, "sha512-Tsbjk8Y2hkBaY/gJsataeb4q9Mubw9EOz7+4RjPkzD5KjTvHHs7cpws22InaoXxAVAhF5HfFbzJjo6oKWqSZLw=="],
 
     "@storybook/jest/jest-mock": ["jest-mock@27.5.1", "", { "dependencies": { "@jest/types": "^27.5.1", "@types/node": "*" } }, "sha512-K4jKbY1d4ENhbrG2zuPWaQBvDly+iZ2yAW+T1fATN78hc0sInwn7wZB8XtlNnvHug5RMwV897Xm4LqmPM4e2Og=="],
@@ -3531,6 +3536,8 @@
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
     "stats-gl/three": ["three@0.170.0", "", {}, "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ=="],
+
+    "storybook/@testing-library/jest-dom": ["@testing-library/jest-dom@6.8.0", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ=="],
 
     "stream-browserify/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 

--- a/package.json
+++ b/package.json
@@ -86,6 +86,8 @@
     "@svgr/webpack": "^8.1.0",
     "@swc/core": "^1.15.8",
     "@tanstack/eslint-plugin-query": "^5.91.2",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/cookie": "^1.0.0",
     "@types/file-saver": "^2.0.7",
     "@types/jest": "^29.5.14",

--- a/src/hooks/useRouteCoach.test.tsx
+++ b/src/hooks/useRouteCoach.test.tsx
@@ -14,9 +14,7 @@ describe('useRouteCoach hooks', () => {
     appStore = store();
   });
 
-  const wrapper = ({ children }: { children: React.ReactNode }) => (
-    <Provider store={appStore}>{children}</Provider>
-  );
+  const wrapper = ({ children }: { children: React.ReactNode }) => <Provider store={appStore}>{children}</Provider>;
 
   describe('useRouteCoachSelect', () => {
     it('should return the correct initial value', () => {
@@ -32,7 +30,7 @@ describe('useRouteCoach hooks', () => {
           patch: useRouteCoachPatch(),
           selectedClusterId: useRouteCoachSelect((s) => s.selectedClusterId),
         }),
-        { wrapper }
+        { wrapper },
       );
 
       expect(result.current.selectedClusterId).toBeNull();

--- a/src/hooks/useRouteCoach.test.tsx
+++ b/src/hooks/useRouteCoach.test.tsx
@@ -1,0 +1,63 @@
+/** @jest-environment jsdom */
+import { renderHook, act } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+
+import { useRouteCoachSelect, useRouteCoachPatch, useSelectedClusterId } from './useRouteCoach';
+
+import { store } from '@src/store';
+
+describe('useRouteCoach hooks', () => {
+  let appStore: ReturnType<typeof store>;
+
+  beforeEach(() => {
+    appStore = store();
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <Provider store={appStore}>{children}</Provider>
+  );
+
+  describe('useRouteCoachSelect', () => {
+    it('should return the correct initial value', () => {
+      const { result } = renderHook(() => useRouteCoachSelect((s) => s.selectedClusterId), { wrapper });
+      expect(result.current).toBeNull();
+    });
+  });
+
+  describe('useRouteCoachPatch', () => {
+    it('should patch the route coach settings', () => {
+      const { result } = renderHook(
+        () => ({
+          patch: useRouteCoachPatch(),
+          selectedClusterId: useRouteCoachSelect((s) => s.selectedClusterId),
+        }),
+        { wrapper }
+      );
+
+      expect(result.current.selectedClusterId).toBeNull();
+
+      act(() => {
+        result.current.patch({ selectedClusterId: 10 });
+      });
+
+      expect(result.current.selectedClusterId).toBe(10);
+    });
+  });
+
+  describe('useSelectedClusterId', () => {
+    it('should return the selected cluster id', () => {
+      const { result } = renderHook(() => useSelectedClusterId(), { wrapper });
+      expect(result.current).toBeNull();
+
+      act(() => {
+        appStore.dispatch({
+          type: 'routeCoach/patchRouteCoach',
+          payload: { selectedClusterId: 42 },
+        });
+      });
+
+      expect(result.current).toBe(42);
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for `useRouteCoach` hooks to improve test coverage and reliability. The hooks wrapper standard `react-redux` `useSelector` and `useDispatch` calls, making them straightforward to test using a mock store and `renderHook` from `@testing-library/react`.

📊 **Coverage:** Covered happy paths for selecting data, dispatching a patch, and verifying that the patched state is reflected in the selectors. All hooks in `useRouteCoach.ts` (`useRouteCoachSelect`, `useRouteCoachPatch`, and `useSelectedClusterId`) are now tested.

✨ **Result:** Increased test coverage for Redux hooks, providing a safety net for confident refactoring and catching potential bugs related to state management.

---
*PR created automatically by Jules for task [5861233709384604249](https://jules.google.com/task/5861233709384604249) started by @Matuyuhi*