### PR TITLE
fix(security): 認証Cookieを SameSite=Lax にし PII ログを除去

### DIFF
--- a/src/pages/api/auth/session.api.ts
+++ b/src/pages/api/auth/session.api.ts
@@ -38,19 +38,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     // Get auth token from httpOnly cookie
     const authToken = getCookie(req.headers.cookie, COOKIE_NAMES.AUTH_TOKEN);
 
-    // eslint-disable-next-line no-console
-    console.log('[Auth] Session check - Cookie found:', !!authToken);
-
     if (!authToken) {
-      // eslint-disable-next-line no-console
-      console.log('[Auth] Session check - No auth token in cookie');
       return res.status(200).json({ authenticated: false });
     }
 
     // Verify token with backend API (use same endpoint as social-callback)
     const apiUrl = `${env.NEXT_PUBLIC_API_BASE_URL}/api/v0/login/profile`;
-    // eslint-disable-next-line no-console
-    console.log('[Auth] Session check - Verifying with backend:', apiUrl);
 
     const apiResponse = await fetch(apiUrl, {
       method: 'GET',
@@ -60,19 +53,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       },
     });
 
-    // eslint-disable-next-line no-console
-    console.log('[Auth] Session check - Backend response status:', apiResponse.status);
-
     if (!apiResponse.ok) {
       // Token is invalid or expired
-      // eslint-disable-next-line no-console
-      console.log('[Auth] Session check - Token validation failed');
       return res.status(200).json({ authenticated: false });
     }
 
     const userData = await apiResponse.json();
-    // eslint-disable-next-line no-console
-    console.log('[Auth] Session check - Success, user:', userData.email || userData.id);
 
     return res.status(200).json({
       user: userData,

--- a/src/pages/api/auth/social-callback.api.ts
+++ b/src/pages/api/auth/social-callback.api.ts
@@ -43,20 +43,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   try {
     const { token, redirect } = req.query as SocialCallbackQuery;
 
-    // eslint-disable-next-line no-console
-    console.log('[Auth] Social callback - Received request, token present:', !!token);
-
     // Validate token parameter
     if (!token || typeof token !== 'string') {
-      // eslint-disable-next-line no-console
-      console.log('[Auth] Social callback - Missing or invalid token');
       return res.status(400).json({ error: 'Missing or invalid token parameter' });
     }
 
     // Validate token by fetching user profile from backend
     const apiUrl = `${env.NEXT_PUBLIC_API_BASE_URL}/api/v0/login/profile`;
-    // eslint-disable-next-line no-console
-    console.log('[Auth] Social callback - Validating token with:', apiUrl);
 
     const apiResponse = await fetch(apiUrl, {
       method: 'GET',
@@ -66,18 +59,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       },
     });
 
-    // eslint-disable-next-line no-console
-    console.log('[Auth] Social callback - Backend response status:', apiResponse.status);
-
     if (!apiResponse.ok) {
-      // eslint-disable-next-line no-console
-      console.log('[Auth] Social callback - Token validation failed');
       return res.status(401).json({ error: 'Invalid token' });
     }
 
     const userData = await apiResponse.json();
-    // eslint-disable-next-line no-console
-    console.log('[Auth] Social callback - User data received:', userData.email || userData.id);
 
     if (!userData) {
       return res.status(500).json({ error: 'Failed to fetch user data' });
@@ -87,16 +73,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const csrfToken = generateCsrfToken();
 
     // Set httpOnly cookies for security
-    // eslint-disable-next-line no-console
-    console.log('[Auth] Social callback - Setting httpOnly cookies');
     setAuthToken(res, token);
     setCsrfToken(res, csrfToken);
 
     // Determine redirect URL (default to callback success page)
     const isValidRedirect = typeof redirect === 'string' && redirect.startsWith('/') && !redirect.startsWith('//') && !redirect.startsWith('/\\');
     const redirectUrl = isValidRedirect ? redirect : '/auth/social-callback';
-    // eslint-disable-next-line no-console
-    console.log('[Auth] Social callback - Cookies set, redirecting to:', redirectUrl);
 
     // Return HTML page that redirects client-side
     // This ensures cookies are set before navigation

--- a/src/utils/security/cookies.ts
+++ b/src/utils/security/cookies.ts
@@ -11,20 +11,22 @@ import type { NextApiResponse } from 'next';
  * Default cookie options for secure cookies
  *
  * Development vs Production settings:
- * - Development: Works with HTTP, sameSite 'lax' for local testing
- * - Production: Enforces HTTPS, sameSite 'none' for cross-subdomain requests
+ * - Development: Works with HTTP, sameSite 'lax'
+ * - Production: Enforces HTTPS, sameSite 'lax'
  *
  * Cross-subdomain support:
- * - Frontend: ludiapp.matuyuhi.com
- * - API: matuyuhi.com
- * - Explicit domain: '.matuyuhi.com' allows cookies to be sent across both subdomains
- * - sameSite 'none' is required for fetch requests across subdomains in production
- * - sameSite 'none' requires secure: true (enforced in production)
+ * - Frontend: ludiapp.matuyuhi.com / API: matuyuhi.com
+ * - これらは同一の登録可能ドメイン (eTLD+1 = matuyuhi.com) のため "same-site"。
+ *   domain '.matuyuhi.com' を指定すれば、sameSite 'lax' でもサブドメイン間の
+ *   fetch に Cookie は送信される。
+ * - sameSite 'lax' は true cross-site（別ドメイン）からの非ナビゲーション
+ *   リクエストでは Cookie を送らないため、CSRF 攻撃面を縮小する。'none' は不要で、
+ *   不必要にクロスサイト送信を許してしまうため使用しない。
  */
 const DEFAULT_COOKIE_OPTIONS: SerializeOptions = {
   httpOnly: true, // Prevent JavaScript access (XSS protection)
   secure: process.env.NODE_ENV === 'production', // HTTPS only in production
-  sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax', // 'none' for cross-subdomain requests in production, 'lax' for local testing
+  sameSite: 'lax', // same-site (matuyuhi.com) なので lax で十分。CSRF 面を縮小
   domain: process.env.NODE_ENV === 'production' ? '.matuyuhi.com' : undefined, // Cross-subdomain cookie sharing in production
   path: '/',
   maxAge: 60 * 60 * 24 * 7, // 7 days


### PR DESCRIPTION
## 概要

`/security-review`（コードベース全体監査）で検出したフロントエンド側の指摘（CSRF / PII ログ）を修正します。

## 修正内容

### 🟡 Medium — Cookie の SameSite
- 本番の auth / refresh / csrf Cookie を `SameSite=None` → **`SameSite=Lax`** に変更
  - フロント(`ludiapp.matuyuhi.com`)と API(`matuyuhi.com`)は同一の登録可能ドメイン（eTLD+1 = `matuyuhi.com`）で **same-site**。`domain=.matuyuhi.com` 指定により Lax でもサブドメイン間 fetch には Cookie が送信される
  - 一方で true cross-site（別ドメイン）からの非ナビゲーションリクエストでは Cookie を送らないため、**CSRF 攻撃面を縮小**できる。`None` は不要にクロスサイト送信を許すため使用をやめる
  - `None` が必須と書かれていた誤ったコメントも修正
- ※ embed はヘッダトークン（`x-embed-token`）認証のため本変更の影響を受けない

### 🟡 Low — PII / 情報漏洩ログ
- `session.api.ts` / `social-callback.api.ts` のデバッグ `console.log`（ユーザー email・バックエンド URL・トークン有無）を削除。`console.error`（エラーログ）は維持

## テスト
- `tsc --noEmit`: エラーなし
- 全テスト: **14 suites / 184 tests pass**（`cookies.test.ts` 含む）
- ESLint / Prettier: クリーン

## 補足（本 PR スコープ外・別途検討）
- 監査時の発見として、クライアントは Next.js を介さず backend へ直接通信するため、Next.js 層の double-submit CSRF（`generateCsrfToken` を発行・Cookie/Redux 保存するが `verifyCsrfToken` が未呼び出し）は実質機能していません。実効的な CSRF 対策は今回の `SameSite=Lax`（+ backend 側 Origin 検証）です。未使用 CSRF プラミングの削除や backend Origin 検証は、login レスポンス契約（`{user, csrfToken}`）や Redux state に影響するため本 PR では見送っています
- CSP の `'unsafe-inline' / 'unsafe-eval'` 緩和も別途検討

🤖 Generated with [Claude Code](https://claude.com/claude-code)