### PR TITLE
fix(security): レート制限カウンターをエンドポイント種別ごとに分離

### DIFF
--- a/src/utils/security/rateLimit.ts
+++ b/src/utils/security/rateLimit.ts
@@ -31,6 +31,8 @@ setInterval(() => {
  * Rate limit configuration
  */
 export interface RateLimitConfig {
+  /** Bucket identifier — isolates this endpoint group's counter from others sharing the same IP */
+  name: string;
   /** Maximum number of requests allowed in the time window */
   maxRequests: number;
   /** Time window in seconds */
@@ -44,11 +46,11 @@ export interface RateLimitConfig {
  */
 export const RATE_LIMITS = {
   /** Strict limit for authentication endpoints (5 requests per minute) */
-  AUTH: { maxRequests: 5, windowSeconds: 60 },
+  AUTH: { name: 'auth', maxRequests: 5, windowSeconds: 60 },
   /** Moderate limit for API endpoints (30 requests per minute) */
-  API: { maxRequests: 30, windowSeconds: 60 },
+  API: { name: 'api', maxRequests: 30, windowSeconds: 60 },
   /** Generous limit for read-only endpoints (100 requests per minute) */
-  READ_ONLY: { maxRequests: 100, windowSeconds: 60 },
+  READ_ONLY: { name: 'read_only', maxRequests: 100, windowSeconds: 60 },
 } as const;
 
 /**
@@ -58,20 +60,26 @@ export const RATE_LIMITS = {
  * @returns Client IP address
  */
 function getClientIp(req: NextApiRequest): string {
-  // Check proxy headers first
+  // Amplify/CloudFront forwards the chain as `client, proxy1, proxy2, ...` in X-Forwarded-For,
+  // so the first non-empty entry is the original client IP. Skip blank segments defensively.
   const forwarded = req.headers['x-forwarded-for'];
   if (forwarded) {
-    const ip = typeof forwarded === 'string' ? forwarded.split(',')[0] : forwarded[0];
-    return ip.trim();
+    const raw = Array.isArray(forwarded) ? forwarded[0] : forwarded;
+    const first = raw
+      .split(',')
+      .map((part) => part.trim())
+      .find((part) => part.length > 0);
+    if (first) return first;
   }
 
   const realIp = req.headers['x-real-ip'];
   if (realIp) {
-    return typeof realIp === 'string' ? realIp : realIp[0];
+    const ip = (Array.isArray(realIp) ? realIp[0] : realIp).trim();
+    if (ip) return ip;
   }
 
   // Fallback to socket address
-  return req.socket.remoteAddress || 'unknown';
+  return req.socket?.remoteAddress || 'unknown';
 }
 
 /**
@@ -89,7 +97,11 @@ export function checkRateLimit(
   resetTime: number;
   retryAfter?: number;
 } {
-  const key = config.keyGenerator ? config.keyGenerator(req) : getClientIp(req);
+  // Prefix the key with the bucket name so endpoints with different limits don't share one
+  // counter — otherwise a login (limit 5) gets rejected because read-only/API routes from the
+  // same IP already filled the window.
+  const identity = config.keyGenerator ? config.keyGenerator(req) : getClientIp(req);
+  const key = `${config.name}:${identity}`;
   const now = Date.now();
   const windowMs = config.windowSeconds * 1000;
 


### PR DESCRIPTION
## 背景 / 問題
ログイン時にかなりの確率で `429 {"error":"Too many requests","message":"Rate limit exceeded. Please try again in N seconds.","retryAfter":N}` が発生していた。

このエラーはバックエンド(NestJS)ではなく、**Next.js BFF の in-memory レート制限** (`src/utils/security/rateLimit.ts`) が返している。

## 原因（設計バグ）
`checkRateLimit` のカウンターキーが **クライアント IP のみ** で、`rateLimitStore` も単一 `Map`。一方 `limit` だけがエンドポイント種別ごとに異なる（AUTH=5 / API=30 / READ_ONLY=100）。

その結果、同一 IP からの `login` / `session` / `csrf` / `proxy` など**全 API route のアクセスが単一カウンターを共有**し、ログインページ表示時の `csrf`・`session`・`proxy` 呼び出しでカウントが積み上がる。ログイン押下時には `login.api.ts` が `AUTH(limit=5)` で判定するため、すでにカウントが 5 を超えていて即 429 になっていた。`retryAfter` が固定 60 秒ウィンドウの残り時間である点とも一致する。

## 変更
- `RateLimitConfig` に `name`（バケット識別子）を追加し、`RATE_LIMITS` の各種別に `auth`/`api`/`read_only` を付与
- カウンターキーを `` `${name}:${ip}` `` に変更し、**種別ごとにカウンターを分離**（login が他経路のアクセスに巻き込まれない）
- `getClientIp` を堅牢化（X-Forwarded-For の空要素スキップ・trim・配列/socket ガード、Amplify/CloudFront 経路を考慮）

利用側（`login.api.ts` 等）は `RATE_LIMITS.*` を渡すだけのため変更不要。

## 動作確認
- `bun run type` / `eslint` / `prettier --check` パス
- ローカルでログインページ表示直後にログイン実行 → 429 が出ないこと
- `/api/auth/login` を連続 6 回叩くと 6 回目で初めて 429（auth 単独で 5/分が効く）になること

## 残課題（本 PR スコープ外）
1. `proxy` が `api` バケット(30/分)を `session` 等と共有。heatmap ビューアで proxy を多用すると 30/分に当たる可能性が残る → 必要なら proxy 専用バケット化 or 上限調整。
2. in-memory + `setInterval` は Amplify(Lambda) の複数インスタンス/コールドスタートで状態が一貫しない → 厳密な制限が必要なら Redis 等の共有ストア。

🤖 Generated with [Claude Code](https://claude.com/claude-code)