### PR TITLE
feat(signup): メール + Google 新規登録フローを追加

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -34,6 +34,42 @@ export const en = {
     success: 'Login success',
     errorEmptyFields: 'Please enter email and password',
     forgotPassword: 'Forgot your password?',
+    noAccount: "Don't have an account?",
+    signUpHere: 'Sign up',
+  },
+
+  // Signup page
+  signup: {
+    title: 'Create an account',
+    description: 'Join Ludiscan to start tracking and analyzing your game data.',
+    signUpWithGoogle: 'Sign up with Google',
+    emailStep: {
+      title: 'Enter your email',
+      submit: 'Send verification code',
+      sending: 'Sending...',
+      sent: 'Verification code sent. Please check your inbox.',
+      alreadyRegistered: 'This email is already registered.',
+      errorRequired: 'Please enter your email',
+      errorGeneric: 'Failed to send verification code',
+    },
+    codeStep: {
+      title: 'Verify your email',
+      codeLabel: 'Verification code (6 digits)',
+      codePlaceholder: '123456',
+      passwordLabel: 'Password',
+      passwordPlaceholder: 'password (8+ characters)',
+      confirmPasswordLabel: 'Confirm password',
+      confirmPasswordPlaceholder: 'confirm password',
+      submit: 'Create account',
+      submitting: 'Creating...',
+      errorRequired: 'Please fill in all fields',
+      errorMismatch: 'Passwords do not match',
+      errorTooShort: 'Password must be at least 8 characters',
+      errorInvalidCode: 'Invalid or expired verification code',
+      errorGeneric: 'Failed to create account',
+    },
+    backToLogin: 'Already have an account? Sign in',
+    success: 'Account created successfully',
   },
 
   // Password Reset

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -34,6 +34,42 @@ export const ja = {
     success: 'ログインしました',
     errorEmptyFields: 'メールアドレスとパスワードを入力してください',
     forgotPassword: 'パスワードを忘れた場合',
+    noAccount: 'アカウントをお持ちでない方は',
+    signUpHere: '新規登録',
+  },
+
+  // Signup page
+  signup: {
+    title: 'アカウントを作成',
+    description: 'Ludiscanに参加してゲームデータのトラッキングと分析を始めましょう。',
+    signUpWithGoogle: 'Googleで新規登録',
+    emailStep: {
+      title: 'メールアドレスを入力',
+      submit: '認証コードを送る',
+      sending: '送信中...',
+      sent: '認証コードを送信しました。メールをご確認ください。',
+      alreadyRegistered: 'このメールアドレスは既に登録されています。',
+      errorRequired: 'メールアドレスを入力してください',
+      errorGeneric: '認証コードの送信に失敗しました',
+    },
+    codeStep: {
+      title: 'メールアドレスを確認',
+      codeLabel: '認証コード（6桁）',
+      codePlaceholder: '123456',
+      passwordLabel: 'パスワード',
+      passwordPlaceholder: 'パスワード（8文字以上）',
+      confirmPasswordLabel: 'パスワード（確認）',
+      confirmPasswordPlaceholder: 'パスワードを再入力',
+      submit: 'アカウントを作成',
+      submitting: '作成中...',
+      errorRequired: 'すべての項目を入力してください',
+      errorMismatch: 'パスワードが一致しません',
+      errorTooShort: 'パスワードは8文字以上で入力してください',
+      errorInvalidCode: '認証コードが無効か期限切れです',
+      errorGeneric: 'アカウントの作成に失敗しました',
+    },
+    backToLogin: 'すでにアカウントをお持ちの方はサインイン',
+    success: 'アカウントを作成しました',
   },
 
   // Password Reset

--- a/src/pages/api/auth/signup.api.ts
+++ b/src/pages/api/auth/signup.api.ts
@@ -1,0 +1,87 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { env } from '@src/config/env';
+import { setAuthToken, setCsrfToken } from '@src/utils/security/cookies';
+import { generateCsrfToken } from '@src/utils/security/csrf';
+import { rateLimitMiddleware, RATE_LIMITS } from '@src/utils/security/rateLimit';
+
+interface SignupRequest {
+  email: string;
+  code: string;
+  password: string;
+}
+
+interface SignupResponse {
+  user: {
+    id: string;
+    email: string;
+    name: string;
+  };
+  csrfToken: string;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<SignupResponse | { error: string }>) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const rateLimit = rateLimitMiddleware(RATE_LIMITS.AUTH)(req, res);
+  if (!rateLimit.allowed) return;
+
+  try {
+    const { email, code, password } = req.body as SignupRequest;
+
+    if (!email || !code || !password) {
+      return res.status(400).json({ error: 'Email, code, and password are required' });
+    }
+
+    const apiResponse = await fetch(`${env.NEXT_PUBLIC_API_BASE_URL}/api/v0.1/auth/signup/complete`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, code, password }),
+    });
+
+    if (!apiResponse.ok) {
+      const errorData = await apiResponse.json().catch(() => ({}));
+      return res.status(apiResponse.status).json({
+        error: (errorData as { message?: string }).message || 'Signup failed',
+      });
+    }
+
+    const data = (await apiResponse.json()) as { token: string };
+
+    if (!data.token) {
+      return res.status(500).json({ error: 'Invalid response from authentication server' });
+    }
+
+    // トークンでユーザー情報を取得
+    const profileResponse = await fetch(`${env.NEXT_PUBLIC_API_BASE_URL}/api/v0/login/profile`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${data.token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!profileResponse.ok) {
+      return res.status(500).json({ error: 'Failed to fetch user profile' });
+    }
+
+    const userData = await profileResponse.json();
+
+    if (!userData) {
+      return res.status(500).json({ error: 'Failed to fetch user data' });
+    }
+
+    const csrfToken = generateCsrfToken();
+    setAuthToken(res, data.token);
+    setCsrfToken(res, csrfToken);
+
+    return res.status(200).json({ user: userData, csrfToken });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('[Auth] Signup error:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+}

--- a/src/pages/login/index.page.tsx
+++ b/src/pages/login/index.page.tsx
@@ -155,6 +155,13 @@ const Content: FC<LoginPageProps> = ({ className }) => {
             <Link href='/password-reset/request' className={`${className}__forgotPassword`}>
               {t('login.forgotPassword')}
             </Link>
+            <div className={`${className}__signupRow`}>
+              <Text text={t('login.noAccount')} fontSize={theme.typography.fontSize.sm} color={theme.colors.text.secondary} />
+              {' '}
+              <Link href='/signup' className={`${className}__signupLink`}>
+                {t('login.signUpHere')}
+              </Link>
+            </div>
           </InlineFlexColumn>
         </Card>
       </InnerContent>
@@ -260,6 +267,25 @@ const IndexPage = styled(Component)`
 
     &:hover {
       color: ${({ theme }) => theme.colors.text.primary};
+    }
+  }
+
+  &__signupRow {
+    display: flex;
+    flex-direction: row;
+    gap: 4px;
+    align-items: center;
+  }
+
+  &__signupLink {
+    font-size: ${({ theme }) => theme.typography.fontSize.sm};
+    font-weight: bold;
+    color: ${({ theme }) => theme.colors.primary.main};
+    text-decoration: underline;
+    text-underline-offset: 2px;
+
+    &:hover {
+      opacity: 0.7;
     }
   }
 `;

--- a/src/pages/signup/index.page.tsx
+++ b/src/pages/signup/index.page.tsx
@@ -1,0 +1,374 @@
+import styled from '@emotion/styled';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useCallback, useState } from 'react';
+import { useDispatch } from 'react-redux';
+
+import type { AppDispatch } from '@src/store';
+import type { FC } from 'react';
+
+import { Button } from '@src/component/atoms/Button';
+import { Card } from '@src/component/atoms/Card';
+import { FlexColumn, FlexRow, InlineFlexColumn } from '@src/component/atoms/Flex';
+import { Seo } from '@src/component/atoms/Seo';
+import { VerticalSpacer } from '@src/component/atoms/Spacer';
+import { Text } from '@src/component/atoms/Text';
+import { LanguageSelector } from '@src/component/molecules/LanguageSelector';
+import { LinedText } from '@src/component/molecules/LinedText';
+import { TextField } from '@src/component/molecules/TextField';
+import { DashboardBackgroundCanvas } from '@src/component/templates/DashboardBackgroundCanvas';
+import { Header } from '@src/component/templates/Header';
+import { useToast } from '@src/component/templates/ToastContext';
+import { env } from '@src/config/env';
+import { useIsDesktop } from '@src/hooks/useIsDesktop';
+import { useLocale } from '@src/hooks/useLocale';
+import { useSharedTheme } from '@src/hooks/useSharedTheme';
+import { createClient } from '@src/modeles/qeury';
+import { InnerContent } from '@src/pages/_app.page';
+import { checkSession } from '@src/slices/authSlice';
+import { saveUser } from '@src/utils/localstrage';
+
+type Step = 'email' | 'code';
+
+export type SignupPageProps = {
+  className?: string | undefined;
+};
+
+const Content: FC<SignupPageProps> = ({ className }) => {
+  const router = useRouter();
+  const dispatch = useDispatch<AppDispatch>();
+  const isDesktop = useIsDesktop();
+  const { theme } = useSharedTheme();
+  const { t } = useLocale();
+  const { showToast } = useToast();
+
+  const [step, setStep] = useState<Step>('email');
+  const [email, setEmail] = useState('');
+  const [code, setCode] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSendCode = useCallback(async () => {
+    if (!email) {
+      showToast(t('signup.emailStep.errorRequired'), 2, 'error');
+      return;
+    }
+    setIsLoading(true);
+    try {
+      const { error, response } = await createClient().POST('/api/v0.1/auth/signup/request', {
+        body: { email },
+      });
+      if (response.status === 409) {
+        showToast(t('signup.emailStep.alreadyRegistered'), 3, 'error');
+        return;
+      }
+      if (error) {
+        showToast(t('signup.emailStep.errorGeneric'), 3, 'error');
+        return;
+      }
+      showToast(t('signup.emailStep.sent'), 3, 'success');
+      setStep('code');
+    } catch {
+      showToast(t('signup.emailStep.errorGeneric'), 3, 'error');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [email, showToast, t]);
+
+  const handleComplete = useCallback(async () => {
+    if (!code || !password || !confirmPassword) {
+      showToast(t('signup.codeStep.errorRequired'), 2, 'error');
+      return;
+    }
+    if (password !== confirmPassword) {
+      showToast(t('signup.codeStep.errorMismatch'), 2, 'error');
+      return;
+    }
+    if (password.length < 8) {
+      showToast(t('signup.codeStep.errorTooShort'), 2, 'error');
+      return;
+    }
+    setIsLoading(true);
+    try {
+      const res = await fetch('/api/auth/signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ email, code, password }),
+      });
+      if (res.status === 400) {
+        showToast(t('signup.codeStep.errorInvalidCode'), 3, 'error');
+        return;
+      }
+      if (res.status === 409) {
+        showToast(t('signup.emailStep.alreadyRegistered'), 3, 'error');
+        setStep('email');
+        return;
+      }
+      if (!res.ok) {
+        showToast(t('signup.codeStep.errorGeneric'), 3, 'error');
+        return;
+      }
+      const data = await res.json();
+      if (data.user) {
+        saveUser(data.user);
+      }
+      await dispatch(checkSession());
+      showToast(t('signup.success'), 2, 'success');
+      router.replace('/home');
+    } catch {
+      showToast(t('signup.codeStep.errorGeneric'), 3, 'error');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [code, confirmPassword, dispatch, email, password, router, showToast, t]);
+
+  return (
+    <div className={className}>
+      <DashboardBackgroundCanvas />
+      <InnerContent showSidebar={false}>
+        <Header title={''} showSidebar={false} />
+        <Card
+          color={isDesktop ? theme.colors.surface.base : 'unset'}
+          border={theme.colors.border.default}
+          shadow={'medium'}
+          padding={'32px 28px'}
+          className={`${className}__form`}
+        >
+          <InlineFlexColumn gap={24} className={`${className}__content`} align={'center'}>
+            <div style={{ width: '100%', display: 'flex', justifyContent: 'flex-end' }}>
+              <LanguageSelector />
+            </div>
+            <InlineFlexColumn style={{ width: '100%' }} gap={8} align={'flex-start'}>
+              <Text text={step === 'email' ? t('signup.title') : t('signup.codeStep.title')} fontWeight={'bold'} fontSize={theme.typography.fontSize['3xl']} />
+              <Text text={step === 'email' ? t('signup.description') : email} fontSize={theme.typography.fontSize.base} color={theme.colors.text.primary} />
+            </InlineFlexColumn>
+
+            {step === 'email' && (
+              <>
+                <a
+                  className={`${className}__button google-signup`}
+                  href={`${env.NEXT_PUBLIC_API_BASE_URL}/api/v0/auth/google/signup`}
+                  target={'_self'}
+                  rel={'noopener noreferrer'}
+                >
+                  <Image src={'/google.svg'} alt={'google'} width={20} height={20} />
+                  <Text
+                    className={`${className}__buttonText`}
+                    text={t('signup.signUpWithGoogle')}
+                    color={theme.colors.text.primary}
+                    fontSize={theme.typography.fontSize.base}
+                    fontWeight={'bolder'}
+                  />
+                </a>
+                <LinedText
+                  color={theme.colors.text.primary}
+                  lineColor={theme.colors.secondary.light}
+                  text={t('common.or')}
+                  lineThickness={'1px'}
+                  fullWidth={true}
+                />
+                <FlexColumn gap={2} className={`${className}__email`}>
+                  <Text text={t('common.email')} fontSize={theme.typography.fontSize.sm} />
+                  <TextField
+                    onChange={setEmail}
+                    value={email}
+                    id={'signup-email'}
+                    placeholder={t('login.emailPlaceholder')}
+                    type={'email'}
+                    fontSize={theme.typography.fontSize.base}
+                    style={{ width: '100%' }}
+                  />
+                </FlexColumn>
+                <VerticalSpacer size={2} />
+                <Button onClick={handleSendCode} scheme={'primary'} radius={'default'} fontSize={'lg'} width={'full'} disabled={!email || isLoading}>
+                  <Text text={isLoading ? t('signup.emailStep.sending') : t('signup.emailStep.submit')} />
+                </Button>
+              </>
+            )}
+
+            {step === 'code' && (
+              <>
+                <FlexColumn gap={2} className={`${className}__field`}>
+                  <Text text={t('signup.codeStep.codeLabel')} fontSize={theme.typography.fontSize.sm} />
+                  <TextField
+                    onChange={(v) => setCode(v.replace(/\D/g, '').slice(0, 6))}
+                    value={code}
+                    id={'signup-code'}
+                    placeholder={t('signup.codeStep.codePlaceholder')}
+                    type={'number'}
+                    fontSize={theme.typography.fontSize.base}
+                    style={{ width: '100%' }}
+                  />
+                </FlexColumn>
+                <FlexColumn gap={2} className={`${className}__field`}>
+                  <Text text={t('signup.codeStep.passwordLabel')} fontSize={theme.typography.fontSize.sm} />
+                  <TextField
+                    onChange={setPassword}
+                    value={password}
+                    id={'signup-password'}
+                    placeholder={t('signup.codeStep.passwordPlaceholder')}
+                    type={'password'}
+                    fontSize={theme.typography.fontSize.base}
+                    style={{ width: '100%' }}
+                  />
+                </FlexColumn>
+                <FlexColumn gap={2} className={`${className}__field`}>
+                  <Text text={t('signup.codeStep.confirmPasswordLabel')} fontSize={theme.typography.fontSize.sm} />
+                  <TextField
+                    onChange={setConfirmPassword}
+                    value={confirmPassword}
+                    id={'signup-confirm-password'}
+                    placeholder={t('signup.codeStep.confirmPasswordPlaceholder')}
+                    type={'password'}
+                    fontSize={theme.typography.fontSize.base}
+                    style={{ width: '100%' }}
+                  />
+                </FlexColumn>
+                <VerticalSpacer size={2} />
+                <Button
+                  onClick={handleComplete}
+                  scheme={'primary'}
+                  radius={'default'}
+                  fontSize={'lg'}
+                  width={'full'}
+                  disabled={!code || !password || !confirmPassword || isLoading}
+                >
+                  <Text text={isLoading ? t('signup.codeStep.submitting') : t('signup.codeStep.submit')} />
+                </Button>
+                <button className={`${className}__textButton`} onClick={() => setStep('email')}>
+                  <Text
+                    text={'← ' + t('login.emailPlaceholder').replace('example@email.com', email || 'email')}
+                    fontSize={theme.typography.fontSize.sm}
+                    color={theme.colors.text.secondary}
+                  />
+                </button>
+              </>
+            )}
+
+            <FlexRow gap={4} align={'center'}>
+              <Link href='/login' className={`${className}__backToLogin`}>
+                {t('signup.backToLogin')}
+              </Link>
+            </FlexRow>
+          </InlineFlexColumn>
+        </Card>
+      </InnerContent>
+    </div>
+  );
+};
+
+const Component: FC<SignupPageProps> = (props) => {
+  return (
+    <div className={props.className}>
+      <Seo title='Sign up' path='/signup' keywords={['signup', 'register', 'create account']} />
+      <Content {...props} />
+    </div>
+  );
+};
+
+const hexToRgba = (hex: string, alpha: number) => {
+  let c = hex.replace('#', '');
+  if (c.length === 3)
+    c = c
+      .split('')
+      .map((ch) => ch + ch)
+      .join('');
+  const num = parseInt(c, 16);
+  const r = (num >> 16) & 0xff;
+  const g = (num >> 8) & 0xff;
+  const b = num & 0xff;
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+};
+
+const IndexPage = styled(Component)`
+  position: relative;
+  height: 100vh;
+  height: 100dvh;
+  overflow: hidden;
+  color: ${({ theme }) => theme.colors.text.primary};
+  background: #ffeaea;
+
+  &__form {
+    position: relative;
+    z-index: 1;
+    width: 100%;
+    max-width: 500px;
+    margin: 20px;
+  }
+
+  .mobile &__form {
+    max-width: 100%;
+    height: 100%;
+    max-height: unset;
+    margin: 0;
+    background: ${({ theme }) => hexToRgba(theme.colors.surface.base, 0.5)};
+    border: none;
+  }
+
+  &__content {
+    width: 100%;
+  }
+
+  &__email,
+  &__field {
+    width: calc(100% - 48px);
+    color: ${({ theme }) => theme.colors.text.primary};
+  }
+
+  &__button {
+    display: flex;
+    flex-direction: row;
+    gap: 2px;
+    align-content: center;
+    align-items: center;
+    min-height: 24px;
+    padding: 12px 24px;
+    text-decoration: none;
+    background: ${({ theme }) => theme.colors.surface.base};
+    border: 1px solid ${({ theme }) => theme.colors.border.strong};
+    border-radius: 48px;
+  }
+
+  &__button:hover {
+    opacity: 0.6;
+  }
+
+  &__button.google-signup {
+    width: calc(100% - 48px);
+    max-width: 320px;
+  }
+
+  &__buttonText {
+    width: 100%;
+    text-align: center;
+  }
+
+  &__backToLogin {
+    font-size: ${({ theme }) => theme.typography.fontSize.sm};
+    color: ${({ theme }) => theme.colors.text.secondary};
+    text-decoration: underline;
+    text-underline-offset: 2px;
+
+    &:hover {
+      color: ${({ theme }) => theme.colors.text.primary};
+    }
+  }
+
+  &__textButton {
+    padding: 0;
+    cursor: pointer;
+    background: none;
+    border: none;
+
+    &:hover {
+      opacity: 0.7;
+    }
+  }
+`;
+
+export default function SignupPage(props: SignupPageProps) {
+  return <IndexPage {...props} />;
+}


### PR DESCRIPTION
## 概要

webapp に新規登録（サインアップ）導線を追加します。バックエンド（ludiscan-api-v0 #231）でマージ済みの signup エンドポイントを利用します。

## 変更内容

- **2ステップのメールサインアップページ (`/signup`)**
  1. メールアドレス入力 → 6桁の認証コードを送信（`POST /api/v0.1/auth/signup/request`）
  2. 認証コード + パスワード入力 → アカウント作成（Next.js proxy 経由）
- **Google OAuth サインアップ**ボタン（`/api/v0/auth/google/signup` へ遷移）
- **Next.js proxy `/api/auth/signup`**: バックエンドの `signup/complete` を叩き、httpOnly cookie に JWT をセット（login と同じ方式）
- 認証コード送信は型安全な `createClient()` を使用
- ログインページに新規登録リンクを追加、en/ja のロケール追加

## 実装上のポイント

- `handleComplete` は httpOnly cookie をセットするため Next.js proxy 経由（`login.api.ts` と同じパターン）
- サーバーサイド proxy は生 `fetch` でバックエンドを叩く既存規約に準拠
- 認証コードは数値のみの入力に制限（6桁）

## 確認方法

`bun run dev`（port 5173）で `/signup` を開き、以下を確認:
1. メール入力 → 認証コード送信 → メール受信
2. コード + パスワード入力 → アカウント作成 → `/home` リダイレクト
3. Google サインアップボタンの遷移

## 品質チェック

- `bun run type` ✅
- `bun run lint`（eslint + stylelint）✅
- `bun run format:check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
