### PR TITLE
feat(signup): サインアップ無効時(403/SIGNUP_DISABLED)のエラー表示

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -70,6 +70,7 @@ export const en = {
     },
     backToLogin: 'Already have an account? Sign in',
     success: 'Account created successfully',
+    disabled: 'New sign-ups are currently not being accepted.',
   },
 
   // Password Reset

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -70,6 +70,7 @@ export const ja = {
     },
     backToLogin: 'すでにアカウントをお持ちの方はサインイン',
     success: 'アカウントを作成しました',
+    disabled: '現在、新規登録は受け付けていません。',
   },
 
   // Password Reset

--- a/src/pages/signup/index.page.tsx
+++ b/src/pages/signup/index.page.tsx
@@ -60,6 +60,10 @@ const Content: FC<SignupPageProps> = ({ className }) => {
       const { error, response } = await createClient().POST('/api/v0.1/auth/signup/request', {
         body: { email },
       });
+      if (response.status === 403) {
+        showToast(t('signup.disabled'), 3, 'error');
+        return;
+      }
       if (response.status === 409) {
         showToast(t('signup.emailStep.alreadyRegistered'), 3, 'error');
         return;
@@ -98,6 +102,10 @@ const Content: FC<SignupPageProps> = ({ className }) => {
         credentials: 'include',
         body: JSON.stringify({ email, code, password }),
       });
+      if (res.status === 403) {
+        showToast(t('signup.disabled'), 3, 'error');
+        return;
+      }
       if (res.status === 400) {
         showToast(t('signup.codeStep.errorInvalidCode'), 3, 'error');
         return;


### PR DESCRIPTION
## 概要

バックエンド（ludiscan-api-v0 #232, マージ済み）で Email サインアップが `auth.email_signup` feature flag 配下になり、無効時は **403 / `SIGNUP_DISABLED`** を返すようになりました。webapp 側でこの 403 を検出し、サインアップ無効を明示するようにします。

UI の常時出し分け（ボタン非表示等）は行わず、ユーザーがサインアップを試みたタイミングでエラーとして気づける方針です。

## 変更内容

- `signup/index.page.tsx`: `handleSendCode`（認証コード送信 `/signup/request`）・`handleComplete`（アカウント作成）の両方で `status === 403` を検出 → `signup.disabled` トーストを表示
- `en.ts` / `ja.ts`: `signup.disabled` メッセージ追加（「現在、新規登録は受け付けていません。」）

## 確認方法

1. 管理画面で `auth.email_signup` flag を off にする
2. `/signup` でメール入力 → 「認証コードを送る」→ **「現在、新規登録は受け付けていません。」** トースト表示
3. flag を on に戻すと通常通り送信できる

## 品質チェック

- `bun run type` ✅ / `bun run lint` ✅ / `bun run format:check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
