### PR TITLE
feat(heatmap): モデルの位置・回転・スケールを調整して保存（C1）

### DIFF
--- a/src/features/heatmap/HeatmapViewer.tsx
+++ b/src/features/heatmap/HeatmapViewer.tsx
@@ -39,6 +39,7 @@ import { useGeneralPatch, useGeneralPick } from '@src/hooks/useGeneral';
 import { useGetApi } from '@src/hooks/useGetApi';
 import { useLocale } from '@src/hooks/useLocale';
 import { usePlayerTimelinePatch } from '@src/hooks/usePlayerTimeline';
+import { useMapTransform } from '@src/hooks/useUploadMapData';
 import { useFieldObjectTypes } from '@src/modeles/heatmapView';
 import { DefaultStaleTime } from '@src/modeles/qeury';
 import { setMenuPanelCollapsed } from '@src/slices/uiSlice';
@@ -46,6 +47,7 @@ import { dimensions, zIndexes } from '@src/styles/style';
 import { heatMapEventBus } from '@src/utils/canvasEventBus';
 import { getRandomPrimitiveColor } from '@src/utils/color';
 import { detectDimensionality } from '@src/utils/heatmap/detectDimensionality';
+import { transformToAlignmentPatch } from '@src/utils/heatmap/modelTransform';
 
 // デフォルトのHVQLクエリ（FieldObject用）
 const DEFAULT_FIELD_OBJECT_HVQL = `map status.hand {
@@ -147,6 +149,9 @@ const Component: FC<HeatmapViewerProps> = ({ className, service, isEmbed = false
     staleTime: 1000 * 60 * 20,
     enabled: !!mapName && service.isInitialized,
   });
+
+  // モデルの配置情報（位置・回転・スケール）をキャッシュなしで取得
+  const { data: mapTransform } = useMapTransform(mapName ?? undefined, !!mapName && service.isInitialized);
 
   const { data: generalLogKeys } = useQuery({
     queryKey: ['generalLogKeys', service.projectId, service.sessionId],
@@ -360,6 +365,19 @@ const Component: FC<HeatmapViewerProps> = ({ className, service, isEmbed = false
       setGeneral({ heatmapType: 'fill' });
     }
   }, [model, setGeneral]);
+
+  // サーバーに保存された配置情報（transform）をマップごとに1回 general state へ反映
+  // （バイナリと別のキャッシュなしエンドポイントから取得し、リフェッチでは上書きしない）
+  const appliedTransformMapRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!mapName) return;
+    if (mapTransform === undefined) return; // 取得前
+    if (appliedTransformMapRef.current === mapName) return; // このマップは適用済み
+    appliedTransformMapRef.current = mapName;
+    if (mapTransform) {
+      setGeneral(transformToAlignmentPatch(mapTransform));
+    }
+  }, [mapName, mapTransform, setGeneral]);
 
   // ローカルモデル変更ハンドラ
   const handleLocalModelChange = useCallback((data: LocalModelData | null) => {

--- a/src/features/heatmap/menu/MapMenuContent.tsx
+++ b/src/features/heatmap/menu/MapMenuContent.tsx
@@ -20,7 +20,8 @@ import { InputRow } from '@src/features/heatmap/menu/InputRow';
 import { useGeneralPatch, useGeneralPick, useGeneralSelect } from '@src/hooks/useGeneral';
 import { useLocale } from '@src/hooks/useLocale';
 import { useSharedTheme } from '@src/hooks/useSharedTheme';
-import { useUploadMapData } from '@src/hooks/useUploadMapData';
+import { useUpdateMapTransform, useUploadMapData } from '@src/hooks/useUploadMapData';
+import { alignmentToTransform } from '@src/utils/heatmap/modelTransform';
 
 const UploadSection = styled.div`
   display: flex;
@@ -341,17 +342,19 @@ export const MapMenuContent: FC<HeatmapMenuProps> = ({
   const { theme } = useSharedTheme();
   const { t } = useLocale();
   const mapName = useGeneralSelect((s) => s.mapName);
-  const { modelPositionX, modelPositionY, modelPositionZ, modelRotationX, modelRotationY, modelRotationZ, showMapIn2D } = useGeneralPick(
+  const { modelPositionX, modelPositionY, modelPositionZ, modelRotationX, modelRotationY, modelRotationZ, scale, showMapIn2D } = useGeneralPick(
     'modelPositionX',
     'modelPositionY',
     'modelPositionZ',
     'modelRotationX',
     'modelRotationY',
     'modelRotationZ',
+    'scale',
     'showMapIn2D',
   );
   const setData = useGeneralPatch();
   const uploadMapData = useUploadMapData();
+  const updateMapTransform = useUpdateMapTransform();
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [statusMessage, setStatusMessage] = useState<{ text: string; status: 'success' | 'error' | 'info' } | null>(null);
   const [isAlignmentOpen, setIsAlignmentOpen] = useState(false);
@@ -463,6 +466,8 @@ export const MapMenuContent: FC<HeatmapMenuProps> = ({
       await uploadMapData.mutateAsync({
         mapName: mapName,
         file: selectedFile,
+        // 現在の配置情報（位置・回転・スケール）を一緒に保存
+        transform: alignmentToTransform({ modelPositionX, modelPositionY, modelPositionZ, modelRotationX, modelRotationY, modelRotationZ, scale }),
       });
       setStatusMessage({ text: 'Upload successful!', status: 'success' });
       setSelectedFile(null);
@@ -472,7 +477,25 @@ export const MapMenuContent: FC<HeatmapMenuProps> = ({
         status: 'error',
       });
     }
-  }, [selectedFile, mapName, uploadMapData]);
+  }, [selectedFile, mapName, uploadMapData, modelPositionX, modelPositionY, modelPositionZ, modelRotationX, modelRotationY, modelRotationZ, scale]);
+
+  // 配置情報のみをサーバーに保存（ファイル再アップロード不要）
+  const handleSaveAlignment = useCallback(async () => {
+    if (!mapName) return;
+    setStatusMessage({ text: 'Saving alignment...', status: 'info' });
+    try {
+      await updateMapTransform.mutateAsync({
+        mapName,
+        transform: alignmentToTransform({ modelPositionX, modelPositionY, modelPositionZ, modelRotationX, modelRotationY, modelRotationZ, scale }),
+      });
+      setStatusMessage({ text: 'Alignment saved!', status: 'success' });
+    } catch (error) {
+      setStatusMessage({
+        text: `Failed to save alignment: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        status: 'error',
+      });
+    }
+  }, [mapName, updateMapTransform, modelPositionX, modelPositionY, modelPositionZ, modelRotationX, modelRotationY, modelRotationZ, scale]);
 
   const is2DMode = dimensionality === '2d';
 
@@ -625,23 +648,35 @@ export const MapMenuContent: FC<HeatmapMenuProps> = ({
                     />
                   </FlexRow>
                 </InputRow>
+                <InputRow label={'Scale'}>
+                  <FlexRow gap={4} align='center'>
+                    <DraggableNumberInput label='S' value={scale} onChange={(v) => setData({ scale: v })} min={0.01} step={0.1} precision={2} />
+                  </FlexRow>
+                </InputRow>
                 <InputRow label={''}>
-                  <Button
-                    scheme={'tertiary'}
-                    fontSize={'sm'}
-                    onClick={() =>
-                      setData({
-                        modelPositionX: 0,
-                        modelPositionY: 0,
-                        modelPositionZ: 0,
-                        modelRotationX: 0,
-                        modelRotationY: 0,
-                        modelRotationZ: 0,
-                      })
-                    }
-                  >
-                    <Text text={'Reset'} fontSize={theme.typography.fontSize.sm} />
-                  </Button>
+                  <FlexRow gap={8} align='center'>
+                    <Button
+                      scheme={'tertiary'}
+                      fontSize={'sm'}
+                      onClick={() =>
+                        setData({
+                          modelPositionX: 0,
+                          modelPositionY: 0,
+                          modelPositionZ: 0,
+                          modelRotationX: 0,
+                          modelRotationY: 0,
+                          modelRotationZ: 0,
+                        })
+                      }
+                    >
+                      <Text text={'Reset'} fontSize={theme.typography.fontSize.sm} />
+                    </Button>
+                    {mapName && !service.isEmbed && (
+                      <Button scheme={'primary'} fontSize={'sm'} onClick={handleSaveAlignment} disabled={updateMapTransform.isPending}>
+                        <Text text={updateMapTransform.isPending ? 'Saving...' : 'Save alignment'} fontSize={theme.typography.fontSize.sm} />
+                      </Button>
+                    )}
+                  </FlexRow>
                 </InputRow>
               </CollapsibleContent>
             </CollapsibleSection>

--- a/src/hooks/useUploadMapData.ts
+++ b/src/hooks/useUploadMapData.ts
@@ -1,10 +1,20 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import type { ModelTransform } from '@src/utils/heatmap/modelTransform';
 
 import { env } from '@src/config/env';
+import { parseTransformHeader } from '@src/utils/heatmap/modelTransform';
 
 interface UploadMapDataParams {
   mapName: string;
   file: File;
+  // モデルの配置情報（位置・回転・スケール）。指定時はファイルと一緒に保存される。
+  transform?: ModelTransform | null;
+}
+
+interface UpdateMapTransformParams {
+  mapName: string;
+  transform: ModelTransform;
 }
 
 /**
@@ -15,9 +25,12 @@ export function useUploadMapData() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async ({ mapName, file }: UploadMapDataParams) => {
+    mutationFn: async ({ mapName, file, transform }: UploadMapDataParams) => {
       const formData = new FormData();
       formData.append('file', file, file.name);
+      if (transform) {
+        formData.append('transform', JSON.stringify(transform));
+      }
 
       const baseUrl = env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost';
       const url = `${baseUrl}/api/v0/heatmap/map_data/${encodeURIComponent(mapName)}`;
@@ -40,6 +53,68 @@ export function useUploadMapData() {
     },
     onSuccess: () => {
       // Invalidate map data queries to refresh available maps
+      queryClient.invalidateQueries({
+        queryKey: ['mapData'],
+      });
+    },
+  });
+}
+
+/**
+ * マップモデルの配置情報（transform）を取得するHook。
+ * バイナリ（map_data）とは別のキャッシュされないエンドポイントから常に最新を取得する。
+ */
+export function useMapTransform(mapName: string | undefined, enabled: boolean) {
+  return useQuery({
+    queryKey: ['mapTransform', mapName],
+    queryFn: async (): Promise<ModelTransform | null> => {
+      if (!mapName) return null;
+      const baseUrl = env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost';
+      const url = `${baseUrl}/api/v0/heatmap/map_data/${encodeURIComponent(mapName)}/transform`;
+      const response = await fetch(url, {
+        method: 'GET',
+        credentials: 'include',
+        mode: 'cors',
+        cache: 'no-store',
+      });
+      if (!response.ok) return null;
+      const data = (await response.json().catch(() => null)) as { transform?: unknown } | null;
+      // 保存済みの値を共通バリデーションで検証して返す
+      return parseTransformHeader(data?.transform != null ? JSON.stringify(data.transform) : null);
+    },
+    enabled: enabled && !!mapName,
+    staleTime: 0,
+  });
+}
+
+/**
+ * アップロード済みマップの配置情報（transform）のみを更新するHook。
+ * ファイルの再アップロードは不要。
+ */
+export function useUpdateMapTransform() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ mapName, transform }: UpdateMapTransformParams) => {
+      const baseUrl = env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost';
+      const url = `${baseUrl}/api/v0/heatmap/map_data/${encodeURIComponent(mapName)}/transform`;
+
+      const response = await fetch(url, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(transform),
+        credentials: 'include',
+        mode: 'cors',
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(`Failed to update transform: ${errorData.message || response.statusText}`);
+      }
+
+      return response.json();
+    },
+    onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ['mapData'],
       });

--- a/src/utils/heatmap/EmbedHeatmapDataService.ts
+++ b/src/utils/heatmap/EmbedHeatmapDataService.ts
@@ -8,6 +8,7 @@ import type { Project } from '@src/modeles/project';
 import type { Session } from '@src/modeles/session';
 
 import { createEmbedClient } from '@src/modeles/qeury';
+import { parseTransformHeader } from '@src/utils/heatmap/modelTransform';
 
 /**
  * ファイル形式文字列をModelFileTypeに変換
@@ -171,7 +172,11 @@ export function useEmbedHeatmapDataService(projectId: number | undefined, sessio
         const fileTypeHeader = response.headers.get('X-Model-File-Type');
         const fileType = parseModelFileType(fileTypeHeader);
 
-        return { data, fileType };
+        // レスポンスヘッダーから配置情報を取得
+        const transformHeader = response.headers.get('X-Model-Transform');
+        const transform = parseTransformHeader(transformHeader);
+
+        return { data, fileType, transform };
       } catch {
         return null;
       }

--- a/src/utils/heatmap/HeatmapDataService.ts
+++ b/src/utils/heatmap/HeatmapDataService.ts
@@ -7,6 +7,7 @@ import type { HeatmapTask, PositionEventLog } from '@src/modeles/heatmaptask';
 import type { Project } from '@src/modeles/project';
 import type { createClient } from '@src/modeles/qeury';
 import type { Session } from '@src/modeles/session';
+import type { ModelTransform } from '@src/utils/heatmap/modelTransform';
 
 // セッション検索パラメータ
 export type SessionSearchParams = {
@@ -20,6 +21,7 @@ export type SessionSearchParams = {
 
 import { useAuth } from '@src/hooks/useAuth';
 import { useApiClient } from '@src/modeles/ApiClientContext';
+import { parseTransformHeader } from '@src/utils/heatmap/modelTransform';
 
 // Field object log type (matches API response)
 export type FieldObjectLog = {
@@ -43,6 +45,8 @@ export type Player = {
 export type MapContentResult = {
   data: ArrayBuffer;
   fileType: ModelFileType | null;
+  // モデルの配置情報（位置・回転・スケール）。未設定の場合は null。
+  transform: ModelTransform | null;
 };
 
 // HeatmapViewer用のデータ取得インターフェース
@@ -290,7 +294,10 @@ export function useOnlineHeatmapDataService(projectId: number | undefined, initi
         const fileTypeHeader = response.headers.get('X-Model-File-Type');
         const fileType = parseModelFileType(fileTypeHeader);
 
-        return { data, fileType };
+        const transformHeader = response.headers.get('X-Model-Transform');
+        const transform = parseTransformHeader(transformHeader);
+
+        return { data, fileType, transform };
       } catch {
         return null;
       }

--- a/src/utils/heatmap/modelTransform.test.ts
+++ b/src/utils/heatmap/modelTransform.test.ts
@@ -1,0 +1,80 @@
+import { alignmentToTransform, parseTransformHeader, transformToAlignmentPatch } from '@src/utils/heatmap/modelTransform';
+
+describe('alignmentToTransform', () => {
+  it('converts degrees to radians and expands uniform scale', () => {
+    const result = alignmentToTransform({
+      modelPositionX: 1,
+      modelPositionY: 2,
+      modelPositionZ: 3,
+      modelRotationX: 0,
+      modelRotationY: 180,
+      modelRotationZ: -90,
+      scale: 2,
+    });
+    expect(result.position).toEqual([1, 2, 3]);
+    expect(result.rotation[0]).toBeCloseTo(0);
+    expect(result.rotation[1]).toBeCloseTo(Math.PI);
+    expect(result.rotation[2]).toBeCloseTo(-Math.PI / 2);
+    expect(result.scale).toEqual([2, 2, 2]);
+  });
+});
+
+describe('transformToAlignmentPatch', () => {
+  it('converts radians to degrees and takes uniform scale from x', () => {
+    const patch = transformToAlignmentPatch({
+      position: [4, 5, 6],
+      rotation: [0, Math.PI, -Math.PI / 2],
+      scale: [3, 3, 3],
+    });
+    expect(patch.modelPositionX).toBe(4);
+    expect(patch.modelPositionY).toBe(5);
+    expect(patch.modelPositionZ).toBe(6);
+    expect(patch.modelRotationX).toBeCloseTo(0);
+    expect(patch.modelRotationY).toBeCloseTo(180);
+    expect(patch.modelRotationZ).toBeCloseTo(-90);
+    expect(patch.scale).toBe(3);
+  });
+
+  it('round-trips with alignmentToTransform', () => {
+    const original = {
+      modelPositionX: 10,
+      modelPositionY: -5,
+      modelPositionZ: 0,
+      modelRotationX: 45,
+      modelRotationY: 90,
+      modelRotationZ: -135,
+      scale: 1.5,
+    };
+    const patch = transformToAlignmentPatch(alignmentToTransform(original));
+    expect(patch.modelPositionX).toBeCloseTo(original.modelPositionX);
+    expect(patch.modelRotationX).toBeCloseTo(original.modelRotationX);
+    expect(patch.modelRotationZ).toBeCloseTo(original.modelRotationZ);
+    expect(patch.scale).toBeCloseTo(original.scale);
+  });
+});
+
+describe('parseTransformHeader', () => {
+  it('parses a valid transform JSON header', () => {
+    const header = JSON.stringify({ position: [1, 2, 3], rotation: [0, 0, 0], scale: [1, 1, 1] });
+    expect(parseTransformHeader(header)).toEqual({
+      position: [1, 2, 3],
+      rotation: [0, 0, 0],
+      scale: [1, 1, 1],
+    });
+  });
+
+  it('returns null for null / empty header', () => {
+    expect(parseTransformHeader(null)).toBeNull();
+    expect(parseTransformHeader('')).toBeNull();
+  });
+
+  it('returns null for malformed JSON', () => {
+    expect(parseTransformHeader('{not json')).toBeNull();
+  });
+
+  it('returns null when a vector has the wrong shape', () => {
+    expect(parseTransformHeader(JSON.stringify({ position: [1, 2], rotation: [0, 0, 0], scale: [1, 1, 1] }))).toBeNull();
+    expect(parseTransformHeader(JSON.stringify({ position: [1, 2, 3], rotation: [0, 0, 0] }))).toBeNull();
+    expect(parseTransformHeader(JSON.stringify({ position: [1, 2, 'x'], rotation: [0, 0, 0], scale: [1, 1, 1] }))).toBeNull();
+  });
+});

--- a/src/utils/heatmap/modelTransform.ts
+++ b/src/utils/heatmap/modelTransform.ts
@@ -1,0 +1,75 @@
+import type { GeneralSettings } from '@src/modeles/heatmapView';
+
+/**
+ * サーバーに保存されるモデルの配置情報。
+ * - position: 位置 [x, y, z]
+ * - rotation: 回転 [x, y, z]（ラジアン）
+ * - scale: スケール [x, y, z]
+ */
+export type ModelTransform = {
+  position: [number, number, number];
+  rotation: [number, number, number];
+  scale: [number, number, number];
+};
+
+const DEG_TO_RAD = Math.PI / 180;
+const RAD_TO_DEG = 180 / Math.PI;
+
+// general state で扱う配置関連フィールド（度・均等スケール）
+type AlignmentFields = Pick<
+  GeneralSettings,
+  'modelPositionX' | 'modelPositionY' | 'modelPositionZ' | 'modelRotationX' | 'modelRotationY' | 'modelRotationZ' | 'scale'
+>;
+
+/**
+ * general state（度・均等スケール）をサーバー保存用 transform（ラジアン・軸別）に変換する。
+ */
+export function alignmentToTransform(g: AlignmentFields): ModelTransform {
+  return {
+    position: [g.modelPositionX, g.modelPositionY, g.modelPositionZ],
+    rotation: [g.modelRotationX * DEG_TO_RAD, g.modelRotationY * DEG_TO_RAD, g.modelRotationZ * DEG_TO_RAD],
+    scale: [g.scale, g.scale, g.scale],
+  };
+}
+
+/**
+ * サーバー保存の transform を general state への部分更新に変換する。
+ * 回転はラジアン→度、スケールは均等とみなして x 成分を採用する。
+ */
+export function transformToAlignmentPatch(t: ModelTransform): Partial<GeneralSettings> {
+  return {
+    modelPositionX: t.position[0],
+    modelPositionY: t.position[1],
+    modelPositionZ: t.position[2],
+    modelRotationX: t.rotation[0] * RAD_TO_DEG,
+    modelRotationY: t.rotation[1] * RAD_TO_DEG,
+    modelRotationZ: t.rotation[2] * RAD_TO_DEG,
+    scale: t.scale[0],
+  };
+}
+
+function isVec3(value: unknown): value is [number, number, number] {
+  return Array.isArray(value) && value.length === 3 && value.every((n) => typeof n === 'number' && Number.isFinite(n));
+}
+
+/**
+ * GET レスポンスの X-Model-Transform ヘッダー（JSON 文字列）を ModelTransform にパースする。
+ * 不正な場合は null を返す。
+ */
+export function parseTransformHeader(header: string | null): ModelTransform | null {
+  if (!header) return null;
+  try {
+    const parsed = JSON.parse(header) as Record<string, unknown>;
+    if (!parsed || typeof parsed !== 'object') return null;
+    if (!isVec3(parsed.position) || !isVec3(parsed.rotation) || !isVec3(parsed.scale)) {
+      return null;
+    }
+    return {
+      position: parsed.position,
+      rotation: parsed.rotation,
+      scale: parsed.scale,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/utils/heatmap/useOfflineHeatmapDataService.ts
+++ b/src/utils/heatmap/useOfflineHeatmapDataService.ts
@@ -33,7 +33,8 @@ export function useOfflineHeatmapDataService(offlineData: OfflineHeatmapData | n
         }
 
         // オフラインモードではファイル形式をデータから取得できないため、デフォルトでobjとして扱う
-        return { data: bytes.buffer, fileType: 'obj' };
+        // 配置情報（transform）もオフラインでは取得できないため null
+        return { data: bytes.buffer, fileType: 'obj', transform: null };
       } catch (error) {
         // eslint-disable-next-line no-console
         console.error('モデルデータのデコードに失敗しました:', error);


### PR DESCRIPTION
## 概要

ヒートマップのマップモデル（3Dモデル）の **位置・回転・スケールを調整し、マップごとにサーバーへ永続化**できるようにします。保存した配置は、そのマップを開いた全ユーザーに適用されます（C1: 数値入力ベース。3Dギズモは後続のC2で対応）。

バックエンド: ludiscan-api-v0 #233（マージ済み）+ #234（GET エンドポイント）

## 変更内容

- **`utils/heatmap/modelTransform.ts`**（新規）: `ModelTransform` 型 + 変換ヘルパー（度↔ラジアン・均等スケール↔軸別）+ ヘッダーパーサ。ユニットテスト付き
- **`useUploadMapData`**: アップロード時に配置情報を FormData で同梱
- **`useUpdateMapTransform`**: ファイル再アップロードなしで配置のみ保存（PATCH）
- **`useMapTransform`**: キャッシュされない専用エンドポイントから配置を都度取得（`cache: no-store`）
- **`HeatmapDataService` / Embed / offline**: `MapContentResult` に transform を追加
- **`HeatmapViewer`**: マップ読み込み時にサーバーの配置を general state へ反映（マップごと1回・リフェッチで上書きしないガード付き）
- **`MapMenuContent`**: 「Model Alignment」に **Scale 入力**と **「Save alignment」ボタン**を追加（既存は位置・回転のみ）

## 設計ポイント

- 既存の Redux general state（`modelPosition/Rotation/scale`）をそのまま活用し、新規 state を作らず一貫性を維持
- transform はバイナリ（キャッシュあり）と分離した no-store エンドポイントから取得 → 保存後リロードで確実に反映（キャッシュ起因の未反映を回避）
- PATCH / GET transform は raw fetch のため spec 型に依存せず動作（spec 再生成不要）
- ラベルは周辺コードに合わせハードコード（この領域は i18n 未対応のため）

## 確認方法（ローカル動作確認済み）

1. アップロード済みマップを選択 → Model Alignment で位置・回転・スケールを調整
2. 「Save alignment」で配置のみ保存（または「Upload」でファイル+配置）
3. リロード → 保存した配置でモデルが表示され、入力欄にも値が復元される

## 品質チェック

- `bun run type` ✅ / `bun run lint` ✅ / `bun run format:check` ✅ / modelTransform テスト 7/7 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
