### PR TITLE
feat(heatmap): model 呼び出しの project スコープ化 + インポートUI

### DIFF
--- a/src/features/heatmap/HeatmapViewer.tsx
+++ b/src/features/heatmap/HeatmapViewer.tsx
@@ -151,7 +151,7 @@ const Component: FC<HeatmapViewerProps> = ({ className, service, isEmbed = false
   });
 
   // モデルの配置情報（位置・回転・スケール）をキャッシュなしで取得
-  const { data: mapTransform } = useMapTransform(mapName ?? undefined, !!mapName && service.isInitialized);
+  const { data: mapTransform } = useMapTransform(service.projectId, mapName ?? undefined, !!mapName && service.isInitialized);
 
   const { data: generalLogKeys } = useQuery({
     queryKey: ['generalLogKeys', service.projectId, service.sessionId],

--- a/src/features/heatmap/MapModelPreview.tsx
+++ b/src/features/heatmap/MapModelPreview.tsx
@@ -1,0 +1,80 @@
+import { OrbitControls } from '@react-three/drei';
+import { Canvas, useThree } from '@react-three/fiber';
+import { useEffect } from 'react';
+import { Box3, MathUtils, Vector3 } from 'three';
+
+import type { ModelFileType } from '@src/features/heatmap/ModelLoader';
+import type { FC } from 'react';
+import type { Group } from 'three';
+
+import { useModelFromArrayBuffer } from '@src/features/heatmap/ModelLoader';
+
+export type MapModelPreviewProps = {
+  buffer: ArrayBuffer | null;
+  fileType: ModelFileType | null;
+  // 度・均等スケール（プロジェクトMapsタブの配置エディタと同じ単位）
+  position: [number, number, number];
+  rotationDeg: [number, number, number];
+  scale: number;
+};
+
+/**
+ * モデル読み込み時にカメラをモデル全体が収まる位置へ一度だけ合わせる。
+ * 以降は OrbitControls でユーザーが自由に操作する。
+ */
+const FitCamera: FC<{ model: Group | null }> = ({ model }) => {
+  const camera = useThree((s) => s.camera);
+  const controls = useThree((s) => s.controls) as { target: Vector3; update: () => void } | null;
+
+  useEffect(() => {
+    if (!model) return;
+    const box = new Box3().setFromObject(model);
+    if (box.isEmpty()) return;
+    const size = box.getSize(new Vector3());
+    const center = box.getCenter(new Vector3());
+    const maxDim = Math.max(size.x, size.y, size.z) || 1;
+    const dist = maxDim * 2.2;
+
+    camera.position.set(center.x + dist, center.y + dist, center.z + dist);
+    camera.near = Math.max(dist / 1000, 0.01);
+    camera.far = dist * 1000;
+    if ('updateProjectionMatrix' in camera) camera.updateProjectionMatrix();
+    camera.lookAt(center);
+    if (controls) {
+      controls.target.copy(center);
+      controls.update();
+    }
+  }, [model, camera, controls]);
+
+  return null;
+};
+
+/**
+ * map モデルの軽量3Dプレビュー（heatmap の Redux/Canvas に依存しない自己完結版）。
+ * position/rotation/scale はプレビュー表示にのみ反映する。
+ */
+export const MapModelPreview: FC<MapModelPreviewProps> = ({ buffer, fileType, position, rotationDeg, scale }) => {
+  const model = useModelFromArrayBuffer(buffer, fileType);
+  const rotationRad: [number, number, number] = [MathUtils.degToRad(rotationDeg[0]), MathUtils.degToRad(rotationDeg[1]), MathUtils.degToRad(rotationDeg[2])];
+
+  return (
+    <Canvas camera={{ position: [100, 100, 100], fov: 50, near: 0.1, far: 1_000_000 }}>
+      {/* eslint-disable-next-line react/no-unknown-property */}
+      <ambientLight intensity={1} />
+      {/* eslint-disable-next-line react/no-unknown-property */}
+      <directionalLight position={[1, 2, 1]} intensity={0.8} />
+      {/* eslint-disable-next-line react/no-unknown-property */}
+      <directionalLight position={[-1, 0.5, -1]} intensity={0.3} />
+      <OrbitControls makeDefault />
+      <group
+        position={position} // eslint-disable-line react/no-unknown-property
+        rotation={rotationRad} // eslint-disable-line react/no-unknown-property
+        scale={[scale, scale, scale]}
+      >
+        {/* eslint-disable-next-line react/no-unknown-property */}
+        {model && <primitive object={model} />}
+      </group>
+      <FitCamera model={model} />
+    </Canvas>
+  );
+};

--- a/src/features/heatmap/menu/MapMenuContent.tsx
+++ b/src/features/heatmap/menu/MapMenuContent.tsx
@@ -1,6 +1,7 @@
 import { css, keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
-import { useCallback, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { IoChevronDown, IoChevronUp, IoClose, IoCubeOutline, IoCloudUploadOutline } from 'react-icons/io5';
 
 import type { HeatmapMenuProps, LocalModelData } from '@src/features/heatmap/HeatmapMenuContent';
@@ -20,7 +21,8 @@ import { InputRow } from '@src/features/heatmap/menu/InputRow';
 import { useGeneralPatch, useGeneralPick, useGeneralSelect } from '@src/hooks/useGeneral';
 import { useLocale } from '@src/hooks/useLocale';
 import { useSharedTheme } from '@src/hooks/useSharedTheme';
-import { useUpdateMapTransform, useUploadMapData } from '@src/hooks/useUploadMapData';
+import { useImportMap, useUpdateMapTransform, useUploadMapData } from '@src/hooks/useUploadMapData';
+import { createClient } from '@src/modeles/qeury';
 import { alignmentToTransform } from '@src/utils/heatmap/modelTransform';
 
 const UploadSection = styled.div`
@@ -355,6 +357,8 @@ export const MapMenuContent: FC<HeatmapMenuProps> = ({
   const setData = useGeneralPatch();
   const uploadMapData = useUploadMapData();
   const updateMapTransform = useUpdateMapTransform();
+  const importMap = useImportMap();
+  const [importSourceLabel, setImportSourceLabel] = useState('');
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [statusMessage, setStatusMessage] = useState<{ text: string; status: 'success' | 'error' | 'info' } | null>(null);
   const [isAlignmentOpen, setIsAlignmentOpen] = useState(false);
@@ -455,7 +459,7 @@ export const MapMenuContent: FC<HeatmapMenuProps> = ({
   );
 
   const handleUpload = useCallback(async () => {
-    if (!selectedFile || !mapName) {
+    if (!selectedFile || !mapName || service.projectId === undefined) {
       setStatusMessage({ text: 'Please select a file and a map name', status: 'error' });
       return;
     }
@@ -464,6 +468,7 @@ export const MapMenuContent: FC<HeatmapMenuProps> = ({
 
     try {
       await uploadMapData.mutateAsync({
+        projectId: service.projectId,
         mapName: mapName,
         file: selectedFile,
         // 現在の配置情報（位置・回転・スケール）を一緒に保存
@@ -477,14 +482,27 @@ export const MapMenuContent: FC<HeatmapMenuProps> = ({
         status: 'error',
       });
     }
-  }, [selectedFile, mapName, uploadMapData, modelPositionX, modelPositionY, modelPositionZ, modelRotationX, modelRotationY, modelRotationZ, scale]);
+  }, [
+    selectedFile,
+    mapName,
+    service.projectId,
+    uploadMapData,
+    modelPositionX,
+    modelPositionY,
+    modelPositionZ,
+    modelRotationX,
+    modelRotationY,
+    modelRotationZ,
+    scale,
+  ]);
 
   // 配置情報のみをサーバーに保存（ファイル再アップロード不要）
   const handleSaveAlignment = useCallback(async () => {
-    if (!mapName) return;
+    if (!mapName || service.projectId === undefined) return;
     setStatusMessage({ text: 'Saving alignment...', status: 'info' });
     try {
       await updateMapTransform.mutateAsync({
+        projectId: service.projectId,
         mapName,
         transform: alignmentToTransform({ modelPositionX, modelPositionY, modelPositionZ, modelRotationX, modelRotationY, modelRotationZ, scale }),
       });
@@ -495,7 +513,41 @@ export const MapMenuContent: FC<HeatmapMenuProps> = ({
         status: 'error',
       });
     }
-  }, [mapName, updateMapTransform, modelPositionX, modelPositionY, modelPositionZ, modelRotationX, modelRotationY, modelRotationZ, scale]);
+  }, [mapName, service.projectId, updateMapTransform, modelPositionX, modelPositionY, modelPositionZ, modelRotationX, modelRotationY, modelRotationZ, scale]);
+
+  // インポート元として選べるプロジェクト一覧（現在のプロジェクトを除く）
+  const { data: allProjects } = useQuery({
+    queryKey: ['projects'],
+    queryFn: async () => {
+      const { data, error } = await createClient().GET('/api/v0/projects');
+      if (error) return [];
+      return data ?? [];
+    },
+    enabled: !service.isEmbed && !!mapName,
+  });
+
+  // ラベル（"<name> (#<id>)"）→ projectId の対応。同名プロジェクト衝突を避けるため id を含める。
+  const importSourceOptions = useMemo(() => {
+    const map = new Map<string, number>();
+    (allProjects ?? []).filter((p) => p.id !== service.projectId).forEach((p) => map.set(`${p.name} (#${p.id})`, p.id));
+    return map;
+  }, [allProjects, service.projectId]);
+
+  const handleImport = useCallback(async () => {
+    const sourceProjectId = importSourceOptions.get(importSourceLabel);
+    if (!mapName || service.projectId === undefined || sourceProjectId === undefined) return;
+    setStatusMessage({ text: 'Importing...', status: 'info' });
+    try {
+      await importMap.mutateAsync({ projectId: service.projectId, mapName, sourceProjectId });
+      setStatusMessage({ text: 'Import successful!', status: 'success' });
+      setImportSourceLabel('');
+    } catch (error) {
+      setStatusMessage({
+        text: `Import failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        status: 'error',
+      });
+    }
+  }, [importSourceOptions, importSourceLabel, mapName, service.projectId, importMap]);
 
   const is2DMode = dimensionality === '2d';
 
@@ -693,6 +745,23 @@ export const MapMenuContent: FC<HeatmapMenuProps> = ({
                 <Text text={uploadMapData.isPending ? 'Uploading...' : 'Upload'} />
               </Button>
               {statusMessage && <StatusMessage status={statusMessage.status}>{statusMessage.text}</StatusMessage>}
+            </UploadSection>
+          )}
+
+          {/* 別プロジェクトから同名マップのモデルを取り込む（要・取り込み先の管理権限） */}
+          {!service.isEmbed && mapName && importSourceOptions.size > 0 && (
+            <UploadSection>
+              <Text text={`Import "${mapName}" from another project`} fontSize={theme.typography.fontSize.base} />
+              <Selector
+                onChange={setImportSourceLabel}
+                options={Array.from(importSourceOptions.keys())}
+                value={importSourceLabel}
+                fontSize={'sm'}
+                disabled={importMap.isPending}
+              />
+              <Button scheme={'secondary'} fontSize={'base'} onClick={handleImport} disabled={!importSourceLabel || importMap.isPending}>
+                <Text text={importMap.isPending ? 'Importing...' : 'Import'} />
+              </Button>
             </UploadSection>
           )}
         </>

--- a/src/hooks/useUploadMapData.ts
+++ b/src/hooks/useUploadMapData.ts
@@ -7,6 +7,7 @@ import { createClient } from '@src/modeles/qeury';
 import { toModelTransform } from '@src/utils/heatmap/modelTransform';
 
 interface UploadMapDataParams {
+  projectId: number;
   mapName: string;
   file: File;
   // モデルの配置情報（位置・回転・スケール）。指定時はファイルと一緒に保存される。
@@ -14,8 +15,17 @@ interface UploadMapDataParams {
 }
 
 interface UpdateMapTransformParams {
+  projectId: number;
   mapName: string;
   transform: ModelTransform;
+}
+
+interface ImportMapParams {
+  // 取り込み先プロジェクト（管理権限が必要）
+  projectId: number;
+  mapName: string;
+  // 取り込み元プロジェクト（閲覧権限が必要）
+  sourceProjectId: number;
 }
 
 /**
@@ -26,7 +36,7 @@ export function useUploadMapData() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async ({ mapName, file, transform }: UploadMapDataParams) => {
+    mutationFn: async ({ projectId, mapName, file, transform }: UploadMapDataParams) => {
       const formData = new FormData();
       formData.append('file', file, file.name);
       if (transform) {
@@ -34,7 +44,7 @@ export function useUploadMapData() {
       }
 
       const baseUrl = env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost';
-      const url = `${baseUrl}/api/v0/heatmap/map_data/${encodeURIComponent(mapName)}`;
+      const url = `${baseUrl}/api/v0/heatmap/projects/${projectId}/map_data/${encodeURIComponent(mapName)}`;
 
       // Content-Typeは設定しない（ブラウザが自動でmultipart/form-data; boundary=...を設定）
       // credentials: 'include'でcookie認証を維持
@@ -65,19 +75,19 @@ export function useUploadMapData() {
  * マップモデルの配置情報（transform）を取得するHook。
  * バイナリ（map_data）とは別のキャッシュされないエンドポイントから常に最新を取得する。
  */
-export function useMapTransform(mapName: string | undefined, enabled: boolean) {
+export function useMapTransform(projectId: number | undefined, mapName: string | undefined, enabled: boolean) {
   return useQuery({
-    queryKey: ['mapTransform', mapName],
+    queryKey: ['mapTransform', projectId, mapName],
     queryFn: async (): Promise<ModelTransform | null> => {
-      if (!mapName) return null;
-      const { data, error } = await createClient().GET('/api/v0/heatmap/map_data/{map_name}/transform', {
-        params: { path: { map_name: mapName } },
+      if (!mapName || projectId === undefined) return null;
+      const { data, error } = await createClient().GET('/api/v0/heatmap/projects/{project_id}/map_data/{map_name}/transform', {
+        params: { path: { project_id: projectId, map_name: mapName } },
       });
       if (error) return null;
       // サーバー側で検証済みだが、tuple 型へ正規化して返す
       return toModelTransform(data?.transform ?? null);
     },
-    enabled: enabled && !!mapName,
+    enabled: enabled && !!mapName && projectId !== undefined,
     staleTime: 0,
   });
 }
@@ -90,13 +100,41 @@ export function useUpdateMapTransform() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async ({ mapName, transform }: UpdateMapTransformParams) => {
-      const { error } = await createClient().PATCH('/api/v0/heatmap/map_data/{map_name}/transform', {
-        params: { path: { map_name: mapName } },
+    mutationFn: async ({ projectId, mapName, transform }: UpdateMapTransformParams) => {
+      const { error } = await createClient().PATCH('/api/v0/heatmap/projects/{project_id}/map_data/{map_name}/transform', {
+        params: { path: { project_id: projectId, map_name: mapName } },
         body: transform,
       });
       if (error) {
         throw new Error(`Failed to update transform: ${error.message ?? 'Unknown error'}`);
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['mapData'],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['mapTransform'],
+      });
+    },
+  });
+}
+
+/**
+ * 別プロジェクトのモデルを現在のプロジェクトに取り込むHook（コピー）。
+ * 取り込み先で管理権限、取り込み元で閲覧権限が必要。
+ */
+export function useImportMap() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ projectId, mapName, sourceProjectId }: ImportMapParams) => {
+      const { error } = await createClient().POST('/api/v0/heatmap/projects/{project_id}/map_data/{map_name}/import', {
+        params: { path: { project_id: projectId, map_name: mapName } },
+        body: { sourceProjectId },
+      });
+      if (error) {
+        throw new Error(`Failed to import model: ${error.message ?? 'Unknown error'}`);
       }
     },
     onSuccess: () => {

--- a/src/modeles/MockApiClient.ts
+++ b/src/modeles/MockApiClient.ts
@@ -30,7 +30,7 @@ export function createMockApiClient(mockDataDir: string = '/mocks/heatmap'): Api
   });
 
   // Heatmap Map Data (Binary or JSON)
-  router.registerGet('/api/v0/heatmap/map_data/{map_name}', async (params, query, _body, parseAs) => {
+  router.registerGet('/api/v0/heatmap/projects/{project_id}/map_data/{map_name}', async (params, query, _body, parseAs) => {
     const mapName = params.map_name;
 
     if (parseAs === 'arrayBuffer') {

--- a/src/pages/home/projects/[project_id].page.tsx
+++ b/src/pages/home/projects/[project_id].page.tsx
@@ -3,9 +3,10 @@ import styled from '@emotion/styled';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import { BiBarChart, BiUser, BiKey, BiLineChart, BiChevronRight } from 'react-icons/bi';
+import { BiBarChart, BiUser, BiKey, BiLineChart, BiChevronRight, BiCube } from 'react-icons/bi';
 
 import { ProjectDetailsApiKeysTab } from './tabs/ProjectDetailsApiKeysTab';
+import { ProjectDetailsMapsTab } from './tabs/ProjectDetailsMapsTab';
 import { ProjectDetailsMembersTab } from './tabs/ProjectDetailsMembersTab';
 import { ProjectDetailsSessionsTab } from './tabs/ProjectDetailsSessionsTab';
 
@@ -25,7 +26,7 @@ import { useSidebar } from '@src/hooks/useSidebar';
 import { InnerContent } from '@src/pages/_app.page';
 import { getCookie, COOKIE_NAMES } from '@src/utils/security/cookies';
 
-type TabType = 'sessions' | 'members' | 'api-keys';
+type TabType = 'sessions' | 'members' | 'api-keys' | 'maps';
 
 export type ProjectDetailsPageProps = {
   className?: string;
@@ -84,6 +85,7 @@ export const getServerSideProps: GetServerSideProps<ProjectDetailsPageProps> = a
 
 const TABS: { id: TabType; label: string; icon: React.ReactNode }[] = [
   { id: 'sessions', label: 'Sessions', icon: <BiBarChart size={18} /> },
+  { id: 'maps', label: 'Maps', icon: <BiCube size={18} /> },
   { id: 'members', label: 'Members', icon: <BiUser size={18} /> },
   { id: 'api-keys', label: 'API Keys', icon: <BiKey size={18} /> },
 ];
@@ -191,6 +193,7 @@ const Component: FC<ProjectDetailsPageProps> = ({ className, project }) => {
           {/* Tab Content */}
           <div className={`${className}__tabContent`}>
             {activeTab === 'sessions' && <ProjectDetailsSessionsTab project={project} />}
+            {activeTab === 'maps' && <ProjectDetailsMapsTab project={project} />}
             {activeTab === 'members' && <ProjectDetailsMembersTab project={project} />}
             {activeTab === 'api-keys' && <ProjectDetailsApiKeysTab project={project} />}
           </div>

--- a/src/pages/home/projects/tabs/ProjectDetailsMapsTab.tsx
+++ b/src/pages/home/projects/tabs/ProjectDetailsMapsTab.tsx
@@ -1,0 +1,302 @@
+import styled from '@emotion/styled';
+import { useQuery } from '@tanstack/react-query';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import type { ModelFileType } from '@src/features/heatmap/ModelLoader';
+import type { Project } from '@src/modeles/project';
+import type { FC } from 'react';
+
+import { Button } from '@src/component/atoms/Button';
+import { DraggableNumberInput } from '@src/component/atoms/DraggableNumberInput';
+import { FileInput } from '@src/component/atoms/FileInput';
+import { FlexColumn, FlexRow } from '@src/component/atoms/Flex';
+import { Text } from '@src/component/atoms/Text';
+import { Selector } from '@src/component/molecules/Selector';
+import { useToast } from '@src/component/templates/ToastContext';
+import { MapModelPreview } from '@src/features/heatmap/MapModelPreview';
+import { getModelFileType } from '@src/features/heatmap/ModelLoader';
+import { useImportMap, useMapTransform, useUpdateMapTransform, useUploadMapData } from '@src/hooks/useUploadMapData';
+import { createClient } from '@src/modeles/qeury';
+import { alignmentToTransform, transformToAlignmentPatch } from '@src/utils/heatmap/modelTransform';
+
+export type ProjectDetailsMapsTabProps = {
+  className?: string;
+  project: Project;
+};
+
+type Alignment = {
+  modelPositionX: number;
+  modelPositionY: number;
+  modelPositionZ: number;
+  modelRotationX: number;
+  modelRotationY: number;
+  modelRotationZ: number;
+  scale: number;
+};
+
+const IDENTITY: Alignment = {
+  modelPositionX: 0,
+  modelPositionY: 0,
+  modelPositionZ: 0,
+  modelRotationX: 0,
+  modelRotationY: 0,
+  modelRotationZ: 0,
+  scale: 1,
+};
+
+const Component: FC<ProjectDetailsMapsTabProps> = ({ className, project }) => {
+  const { showToast } = useToast();
+
+  const [selectedMap, setSelectedMap] = useState('');
+  const [align, setAlign] = useState<Alignment>(IDENTITY);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [localBuffer, setLocalBuffer] = useState<ArrayBuffer | null>(null);
+  const [localFileType, setLocalFileType] = useState<ModelFileType | null>(null);
+  const [importSourceLabel, setImportSourceLabel] = useState('');
+
+  const uploadMapData = useUploadMapData();
+  const updateMapTransform = useUpdateMapTransform();
+  const importMap = useImportMap();
+
+  // プロジェクトのマップ名一覧
+  const { data: maps } = useQuery({
+    queryKey: ['projectMaps', project.id],
+    queryFn: async () => {
+      const { data, error } = await createClient().GET('/api/v0.1/projects/{project_id}/maps', {
+        params: { path: { project_id: project.id }, query: { activeOnly: false } },
+      });
+      if (error) return [];
+      return data?.maps ?? [];
+    },
+  });
+
+  // 選択マップのサーバーモデル（バイナリ）
+  const { data: serverModel } = useQuery({
+    queryKey: ['mapModelBinary', project.id, selectedMap],
+    queryFn: async (): Promise<{ buffer: ArrayBuffer; fileType: ModelFileType | null } | null> => {
+      if (!selectedMap) return null;
+      const { data, error, response } = await createClient().GET('/api/v0/heatmap/projects/{project_id}/map_data/{map_name}', {
+        params: { path: { project_id: project.id, map_name: selectedMap } },
+        parseAs: 'arrayBuffer',
+      });
+      if (error || !data) return null;
+      const header = response.headers.get('X-Model-File-Type');
+      const fileType = header ? (header.toLowerCase() as ModelFileType) : null;
+      return { buffer: data as ArrayBuffer, fileType };
+    },
+    enabled: !!selectedMap,
+  });
+
+  // 選択マップの配置情報
+  const { data: serverTransform } = useMapTransform(project.id, selectedMap || undefined, !!selectedMap);
+
+  // サーバーの配置でエディタを初期化（ローカルファイル編集中は触らない）
+  useEffect(() => {
+    if (selectedFile) return;
+    if (serverTransform === undefined) return;
+    setAlign(serverTransform ? { ...IDENTITY, ...transformToAlignmentPatch(serverTransform) } : IDENTITY);
+  }, [serverTransform, selectedFile]);
+
+  // インポート元プロジェクト一覧（現在のプロジェクトを除く）
+  const { data: allProjects } = useQuery({
+    queryKey: ['projects'],
+    queryFn: async () => {
+      const { data, error } = await createClient().GET('/api/v0/projects');
+      if (error) return [];
+      return data ?? [];
+    },
+  });
+  const importSourceOptions = useMemo(() => {
+    const map = new Map<string, number>();
+    (allProjects ?? []).filter((p) => p.id !== project.id).forEach((p) => map.set(`${p.name} (#${p.id})`, p.id));
+    return map;
+  }, [allProjects, project.id]);
+
+  const handleSelectMap = useCallback((mapName: string) => {
+    setSelectedMap(mapName);
+    setSelectedFile(null);
+    setLocalBuffer(null);
+    setLocalFileType(null);
+  }, []);
+
+  const handleFileSelect = useCallback(async (file: File | null) => {
+    if (!file) return;
+    const fileType = getModelFileType(file.name);
+    if (!fileType) {
+      setSelectedFile(null);
+      setLocalBuffer(null);
+      setLocalFileType(null);
+      return;
+    }
+    setSelectedFile(file);
+    setLocalFileType(fileType);
+    setLocalBuffer(await file.arrayBuffer());
+  }, []);
+
+  const handleUpload = useCallback(async () => {
+    if (!selectedFile || !selectedMap) return;
+    try {
+      await uploadMapData.mutateAsync({ projectId: project.id, mapName: selectedMap, file: selectedFile, transform: alignmentToTransform(align) });
+      showToast('Upload successful', 2, 'success');
+      setSelectedFile(null);
+      setLocalBuffer(null);
+      setLocalFileType(null);
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : 'Upload failed', 3, 'error');
+    }
+  }, [selectedFile, selectedMap, uploadMapData, project.id, align, showToast]);
+
+  const handleSave = useCallback(async () => {
+    if (!selectedMap) return;
+    try {
+      await updateMapTransform.mutateAsync({ projectId: project.id, mapName: selectedMap, transform: alignmentToTransform(align) });
+      showToast('Alignment saved', 2, 'success');
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : 'Failed to save alignment', 3, 'error');
+    }
+  }, [selectedMap, updateMapTransform, project.id, align, showToast]);
+
+  const handleImport = useCallback(async () => {
+    const sourceProjectId = importSourceOptions.get(importSourceLabel);
+    if (!selectedMap || sourceProjectId === undefined) return;
+    try {
+      await importMap.mutateAsync({ projectId: project.id, mapName: selectedMap, sourceProjectId });
+      showToast('Import successful', 2, 'success');
+      setImportSourceLabel('');
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : 'Import failed', 3, 'error');
+    }
+  }, [importSourceOptions, importSourceLabel, selectedMap, importMap, project.id, showToast]);
+
+  const previewBuffer = localBuffer ?? serverModel?.buffer ?? null;
+  const previewFileType = localBuffer ? localFileType : (serverModel?.fileType ?? null);
+  const patch = (p: Partial<Alignment>) => setAlign((prev) => ({ ...prev, ...p }));
+
+  return (
+    <div className={className}>
+      <FlexColumn gap={16} align='flex-start'>
+        <FlexColumn gap={4} align='flex-start'>
+          <Text text='Map' />
+          <Selector onChange={handleSelectMap} options={maps ?? []} value={selectedMap} fontSize='sm' disabled={(maps ?? []).length === 0} />
+        </FlexColumn>
+
+        {selectedMap && (
+          <>
+            <div className={`${className}__preview`}>
+              {previewBuffer ? (
+                <MapModelPreview
+                  buffer={previewBuffer}
+                  fileType={previewFileType}
+                  position={[align.modelPositionX, align.modelPositionY, align.modelPositionZ]}
+                  rotationDeg={[align.modelRotationX, align.modelRotationY, align.modelRotationZ]}
+                  scale={align.scale}
+                />
+              ) : (
+                <div className={`${className}__empty`}>
+                  <Text text='No model uploaded for this map yet.' />
+                </div>
+              )}
+            </div>
+
+            <FlexColumn gap={8} align='flex-start'>
+              <Text text='Position' />
+              <FlexRow gap={4} align='center'>
+                <DraggableNumberInput label='X' value={align.modelPositionX} onChange={(v) => patch({ modelPositionX: v })} step={1} precision={0} />
+                <DraggableNumberInput label='Y' value={align.modelPositionY} onChange={(v) => patch({ modelPositionY: v })} step={1} precision={0} />
+                <DraggableNumberInput label='Z' value={align.modelPositionZ} onChange={(v) => patch({ modelPositionZ: v })} step={1} precision={0} />
+              </FlexRow>
+              <Text text='Rotation' />
+              <FlexRow gap={4} align='center'>
+                <DraggableNumberInput
+                  label='X'
+                  value={align.modelRotationX}
+                  onChange={(v) => patch({ modelRotationX: v })}
+                  min={-180}
+                  max={180}
+                  step={1}
+                  precision={0}
+                />
+                <DraggableNumberInput
+                  label='Y'
+                  value={align.modelRotationY}
+                  onChange={(v) => patch({ modelRotationY: v })}
+                  min={-180}
+                  max={180}
+                  step={1}
+                  precision={0}
+                />
+                <DraggableNumberInput
+                  label='Z'
+                  value={align.modelRotationZ}
+                  onChange={(v) => patch({ modelRotationZ: v })}
+                  min={-180}
+                  max={180}
+                  step={1}
+                  precision={0}
+                />
+              </FlexRow>
+              <Text text='Scale' />
+              <DraggableNumberInput label='S' value={align.scale} onChange={(v) => patch({ scale: v })} min={0.01} step={0.1} precision={2} />
+              <FlexRow gap={8} align='center'>
+                <Button scheme='tertiary' fontSize='sm' onClick={() => setAlign(IDENTITY)}>
+                  <Text text='Reset' />
+                </Button>
+                <Button scheme='primary' fontSize='sm' onClick={handleSave} disabled={updateMapTransform.isPending}>
+                  <Text text={updateMapTransform.isPending ? 'Saving...' : 'Save alignment'} />
+                </Button>
+              </FlexRow>
+            </FlexColumn>
+
+            <FlexColumn gap={8} align='flex-start'>
+              <Text text={`Upload 3D model for "${selectedMap}"`} />
+              <FlexRow gap={8} align='center'>
+                <FileInput accept='.obj,.fbx' onChange={handleFileSelect} buttonText='Select OBJ/FBX File' fontSize='sm' />
+                {selectedFile && <Text text={selectedFile.name} />}
+              </FlexRow>
+              <Button scheme='primary' fontSize='sm' onClick={handleUpload} disabled={!selectedFile || uploadMapData.isPending}>
+                <Text text={uploadMapData.isPending ? 'Uploading...' : 'Upload'} />
+              </Button>
+            </FlexColumn>
+
+            {importSourceOptions.size > 0 && (
+              <FlexColumn gap={8} align='flex-start'>
+                <Text text={`Import "${selectedMap}" from another project`} />
+                <Selector
+                  onChange={setImportSourceLabel}
+                  options={Array.from(importSourceOptions.keys())}
+                  value={importSourceLabel}
+                  fontSize='sm'
+                  disabled={importMap.isPending}
+                />
+                <Button scheme='secondary' fontSize='sm' onClick={handleImport} disabled={!importSourceLabel || importMap.isPending}>
+                  <Text text={importMap.isPending ? 'Importing...' : 'Import'} />
+                </Button>
+              </FlexColumn>
+            )}
+          </>
+        )}
+      </FlexColumn>
+    </div>
+  );
+};
+
+export const ProjectDetailsMapsTab = styled(Component)`
+  width: 100%;
+
+  &__preview {
+    width: 100%;
+    height: 360px;
+    overflow: hidden;
+    background: ${({ theme }) => theme.colors.surface.sunken};
+    border: 1px solid ${({ theme }) => theme.colors.border.default};
+    border-radius: 8px;
+  }
+
+  &__empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+  }
+`;

--- a/src/utils/heatmap/EmbedHeatmapDataService.ts
+++ b/src/utils/heatmap/EmbedHeatmapDataService.ts
@@ -157,10 +157,11 @@ export function useEmbedHeatmapDataService(projectId: number | undefined, sessio
   const getMapContent = useCallback(
     async (mapName: string): Promise<MapContentResult | null> => {
       try {
-        if (!mapName || mapName === '' || !apiClient) return null;
-        const { data, error, response } = await apiClient.GET('/api/v0/heatmap/map_data/{map_name}', {
+        if (!mapName || mapName === '' || !apiClient || projectId === undefined) return null;
+        const { data, error, response } = await apiClient.GET('/api/v0/heatmap/projects/{project_id}/map_data/{map_name}', {
           params: {
             path: {
+              project_id: projectId,
               map_name: mapName,
             },
           },
@@ -181,7 +182,7 @@ export function useEmbedHeatmapDataService(projectId: number | undefined, sessio
         return null;
       }
     },
-    [apiClient],
+    [apiClient, projectId],
   );
 
   const getGeneralLogKeys = useCallback(async () => {

--- a/src/utils/heatmap/HeatmapDataService.ts
+++ b/src/utils/heatmap/HeatmapDataService.ts
@@ -280,10 +280,11 @@ export function useOnlineHeatmapDataService(projectId: number | undefined, initi
   const getMapContent = useCallback(
     async (mapName: string): Promise<MapContentResult | null> => {
       try {
-        if (!mapName || mapName === '') return null;
-        const { data, error, response } = await apiClient.GET('/api/v0/heatmap/map_data/{map_name}', {
+        if (!mapName || mapName === '' || projectId === undefined) return null;
+        const { data, error, response } = await apiClient.GET('/api/v0/heatmap/projects/{project_id}/map_data/{map_name}', {
           params: {
             path: {
+              project_id: projectId,
               map_name: mapName,
             },
           },
@@ -302,7 +303,7 @@ export function useOnlineHeatmapDataService(projectId: number | undefined, initi
         return null;
       }
     },
-    [apiClient],
+    [apiClient, projectId],
   );
 
   const getGeneralLogKeys = useCallback(async () => {


### PR DESCRIPTION
## 概要

API のモデル・プロジェクト単位化（ludiscan-api-v0 #236）に追従し、webapp の model 系呼び出しを **プロジェクトスコープのパス**（`/heatmap/projects/:project_id/map_data/...`）に変更します。あわせて、**別プロジェクトの同名マップのモデルを取り込むインポートUI**を追加します。

> **base はあえて spec ブランチ `chore/update-api-client-1.43.0`（PR #467）です。** spec を develop に単体マージすると、旧パスを参照する webapp が型エラーで壊れるため、UI をこの spec ブランチに先にマージ → その後 spec(#467) を develop へマージ、という順を想定しています。

## 変更内容

### 既存呼び出しの project スコープ化
- `HeatmapDataService` / `EmbedHeatmapDataService` の `getMapContent` を `/projects/{project_id}/map_data/{map_name}` に
- `useUploadMapData`(POST) / `useMapTransform`(GET) / `useUpdateMapTransform`(PATCH) に `projectId` を追加
- `HeatmapViewer`・`MapMenuContent` で `service.projectId` を渡す
- `MockApiClient` のモックパスも project スコープに更新

### インポートUI
- `useImportMap`（`POST .../import`、コピー）を追加
- `MapMenuContent` に「Import "<map>" from another project」セクション：`GET /api/v0/projects` の一覧（現プロジェクト除外）から取り込み元を選択 → Import
- 同名マップを別プロジェクトからコピー。権限は backend が enforce（target=manage / source=view）、失敗時はトースト表示

## 確認方法

per-project 対応済みの API（#236 マージ + デプロイ or ローカル）に対して:
1. マップ選択 → モデル表示・位置/回転/スケール調整・保存・アップロードがプロジェクト単位で動作
2. 「Import from another project」で別プロジェクトを選び Import → 現プロジェクトに同名マップのモデルがコピーされる

## 品質チェック
- `bun run type` ✅ / `bun run lint` ✅ / `bun run format:check` ✅ / modelTransform テスト 9/9 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
