### PR TITLE
feat(projects): プロジェクト詳細に Maps タブ（heatmap外でのモデル管理）

### DIFF
--- a/src/features/heatmap/MapModelPreview.tsx
+++ b/src/features/heatmap/MapModelPreview.tsx
@@ -1,0 +1,80 @@
+import { OrbitControls } from '@react-three/drei';
+import { Canvas, useThree } from '@react-three/fiber';
+import { useEffect } from 'react';
+import { Box3, MathUtils, Vector3 } from 'three';
+
+import type { ModelFileType } from '@src/features/heatmap/ModelLoader';
+import type { FC } from 'react';
+import type { Group } from 'three';
+
+import { useModelFromArrayBuffer } from '@src/features/heatmap/ModelLoader';
+
+export type MapModelPreviewProps = {
+  buffer: ArrayBuffer | null;
+  fileType: ModelFileType | null;
+  // 度・均等スケール（プロジェクトMapsタブの配置エディタと同じ単位）
+  position: [number, number, number];
+  rotationDeg: [number, number, number];
+  scale: number;
+};
+
+/**
+ * モデル読み込み時にカメラをモデル全体が収まる位置へ一度だけ合わせる。
+ * 以降は OrbitControls でユーザーが自由に操作する。
+ */
+const FitCamera: FC<{ model: Group | null }> = ({ model }) => {
+  const camera = useThree((s) => s.camera);
+  const controls = useThree((s) => s.controls) as { target: Vector3; update: () => void } | null;
+
+  useEffect(() => {
+    if (!model) return;
+    const box = new Box3().setFromObject(model);
+    if (box.isEmpty()) return;
+    const size = box.getSize(new Vector3());
+    const center = box.getCenter(new Vector3());
+    const maxDim = Math.max(size.x, size.y, size.z) || 1;
+    const dist = maxDim * 2.2;
+
+    camera.position.set(center.x + dist, center.y + dist, center.z + dist);
+    camera.near = Math.max(dist / 1000, 0.01);
+    camera.far = dist * 1000;
+    if ('updateProjectionMatrix' in camera) camera.updateProjectionMatrix();
+    camera.lookAt(center);
+    if (controls) {
+      controls.target.copy(center);
+      controls.update();
+    }
+  }, [model, camera, controls]);
+
+  return null;
+};
+
+/**
+ * map モデルの軽量3Dプレビュー（heatmap の Redux/Canvas に依存しない自己完結版）。
+ * position/rotation/scale はプレビュー表示にのみ反映する。
+ */
+export const MapModelPreview: FC<MapModelPreviewProps> = ({ buffer, fileType, position, rotationDeg, scale }) => {
+  const model = useModelFromArrayBuffer(buffer, fileType);
+  const rotationRad: [number, number, number] = [MathUtils.degToRad(rotationDeg[0]), MathUtils.degToRad(rotationDeg[1]), MathUtils.degToRad(rotationDeg[2])];
+
+  return (
+    <Canvas camera={{ position: [100, 100, 100], fov: 50, near: 0.1, far: 1_000_000 }}>
+      {/* eslint-disable-next-line react/no-unknown-property */}
+      <ambientLight intensity={1} />
+      {/* eslint-disable-next-line react/no-unknown-property */}
+      <directionalLight position={[1, 2, 1]} intensity={0.8} />
+      {/* eslint-disable-next-line react/no-unknown-property */}
+      <directionalLight position={[-1, 0.5, -1]} intensity={0.3} />
+      <OrbitControls makeDefault />
+      <group
+        position={position} // eslint-disable-line react/no-unknown-property
+        rotation={rotationRad} // eslint-disable-line react/no-unknown-property
+        scale={[scale, scale, scale]}
+      >
+        {/* eslint-disable-next-line react/no-unknown-property */}
+        {model && <primitive object={model} />}
+      </group>
+      <FitCamera model={model} />
+    </Canvas>
+  );
+};

--- a/src/pages/home/projects/[project_id].page.tsx
+++ b/src/pages/home/projects/[project_id].page.tsx
@@ -3,9 +3,10 @@ import styled from '@emotion/styled';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import { BiBarChart, BiUser, BiKey, BiLineChart, BiChevronRight } from 'react-icons/bi';
+import { BiBarChart, BiUser, BiKey, BiLineChart, BiChevronRight, BiCube } from 'react-icons/bi';
 
 import { ProjectDetailsApiKeysTab } from './tabs/ProjectDetailsApiKeysTab';
+import { ProjectDetailsMapsTab } from './tabs/ProjectDetailsMapsTab';
 import { ProjectDetailsMembersTab } from './tabs/ProjectDetailsMembersTab';
 import { ProjectDetailsSessionsTab } from './tabs/ProjectDetailsSessionsTab';
 
@@ -25,7 +26,7 @@ import { useSidebar } from '@src/hooks/useSidebar';
 import { InnerContent } from '@src/pages/_app.page';
 import { getCookie, COOKIE_NAMES } from '@src/utils/security/cookies';
 
-type TabType = 'sessions' | 'members' | 'api-keys';
+type TabType = 'sessions' | 'members' | 'api-keys' | 'maps';
 
 export type ProjectDetailsPageProps = {
   className?: string;
@@ -84,6 +85,7 @@ export const getServerSideProps: GetServerSideProps<ProjectDetailsPageProps> = a
 
 const TABS: { id: TabType; label: string; icon: React.ReactNode }[] = [
   { id: 'sessions', label: 'Sessions', icon: <BiBarChart size={18} /> },
+  { id: 'maps', label: 'Maps', icon: <BiCube size={18} /> },
   { id: 'members', label: 'Members', icon: <BiUser size={18} /> },
   { id: 'api-keys', label: 'API Keys', icon: <BiKey size={18} /> },
 ];
@@ -191,6 +193,7 @@ const Component: FC<ProjectDetailsPageProps> = ({ className, project }) => {
           {/* Tab Content */}
           <div className={`${className}__tabContent`}>
             {activeTab === 'sessions' && <ProjectDetailsSessionsTab project={project} />}
+            {activeTab === 'maps' && <ProjectDetailsMapsTab project={project} />}
             {activeTab === 'members' && <ProjectDetailsMembersTab project={project} />}
             {activeTab === 'api-keys' && <ProjectDetailsApiKeysTab project={project} />}
           </div>

--- a/src/pages/home/projects/tabs/ProjectDetailsMapsTab.tsx
+++ b/src/pages/home/projects/tabs/ProjectDetailsMapsTab.tsx
@@ -1,0 +1,302 @@
+import styled from '@emotion/styled';
+import { useQuery } from '@tanstack/react-query';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import type { ModelFileType } from '@src/features/heatmap/ModelLoader';
+import type { Project } from '@src/modeles/project';
+import type { FC } from 'react';
+
+import { Button } from '@src/component/atoms/Button';
+import { DraggableNumberInput } from '@src/component/atoms/DraggableNumberInput';
+import { FileInput } from '@src/component/atoms/FileInput';
+import { FlexColumn, FlexRow } from '@src/component/atoms/Flex';
+import { Text } from '@src/component/atoms/Text';
+import { Selector } from '@src/component/molecules/Selector';
+import { useToast } from '@src/component/templates/ToastContext';
+import { MapModelPreview } from '@src/features/heatmap/MapModelPreview';
+import { getModelFileType } from '@src/features/heatmap/ModelLoader';
+import { useImportMap, useMapTransform, useUpdateMapTransform, useUploadMapData } from '@src/hooks/useUploadMapData';
+import { createClient } from '@src/modeles/qeury';
+import { alignmentToTransform, transformToAlignmentPatch } from '@src/utils/heatmap/modelTransform';
+
+export type ProjectDetailsMapsTabProps = {
+  className?: string;
+  project: Project;
+};
+
+type Alignment = {
+  modelPositionX: number;
+  modelPositionY: number;
+  modelPositionZ: number;
+  modelRotationX: number;
+  modelRotationY: number;
+  modelRotationZ: number;
+  scale: number;
+};
+
+const IDENTITY: Alignment = {
+  modelPositionX: 0,
+  modelPositionY: 0,
+  modelPositionZ: 0,
+  modelRotationX: 0,
+  modelRotationY: 0,
+  modelRotationZ: 0,
+  scale: 1,
+};
+
+const Component: FC<ProjectDetailsMapsTabProps> = ({ className, project }) => {
+  const { showToast } = useToast();
+
+  const [selectedMap, setSelectedMap] = useState('');
+  const [align, setAlign] = useState<Alignment>(IDENTITY);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [localBuffer, setLocalBuffer] = useState<ArrayBuffer | null>(null);
+  const [localFileType, setLocalFileType] = useState<ModelFileType | null>(null);
+  const [importSourceLabel, setImportSourceLabel] = useState('');
+
+  const uploadMapData = useUploadMapData();
+  const updateMapTransform = useUpdateMapTransform();
+  const importMap = useImportMap();
+
+  // プロジェクトのマップ名一覧
+  const { data: maps } = useQuery({
+    queryKey: ['projectMaps', project.id],
+    queryFn: async () => {
+      const { data, error } = await createClient().GET('/api/v0.1/projects/{project_id}/maps', {
+        params: { path: { project_id: project.id }, query: { activeOnly: false } },
+      });
+      if (error) return [];
+      return data?.maps ?? [];
+    },
+  });
+
+  // 選択マップのサーバーモデル（バイナリ）
+  const { data: serverModel } = useQuery({
+    queryKey: ['mapModelBinary', project.id, selectedMap],
+    queryFn: async (): Promise<{ buffer: ArrayBuffer; fileType: ModelFileType | null } | null> => {
+      if (!selectedMap) return null;
+      const { data, error, response } = await createClient().GET('/api/v0/heatmap/projects/{project_id}/map_data/{map_name}', {
+        params: { path: { project_id: project.id, map_name: selectedMap } },
+        parseAs: 'arrayBuffer',
+      });
+      if (error || !data) return null;
+      const header = response.headers.get('X-Model-File-Type');
+      const fileType = header ? (header.toLowerCase() as ModelFileType) : null;
+      return { buffer: data as ArrayBuffer, fileType };
+    },
+    enabled: !!selectedMap,
+  });
+
+  // 選択マップの配置情報
+  const { data: serverTransform } = useMapTransform(project.id, selectedMap || undefined, !!selectedMap);
+
+  // サーバーの配置でエディタを初期化（ローカルファイル編集中は触らない）
+  useEffect(() => {
+    if (selectedFile) return;
+    if (serverTransform === undefined) return;
+    setAlign(serverTransform ? { ...IDENTITY, ...transformToAlignmentPatch(serverTransform) } : IDENTITY);
+  }, [serverTransform, selectedFile]);
+
+  // インポート元プロジェクト一覧（現在のプロジェクトを除く）
+  const { data: allProjects } = useQuery({
+    queryKey: ['projects'],
+    queryFn: async () => {
+      const { data, error } = await createClient().GET('/api/v0/projects');
+      if (error) return [];
+      return data ?? [];
+    },
+  });
+  const importSourceOptions = useMemo(() => {
+    const map = new Map<string, number>();
+    (allProjects ?? []).filter((p) => p.id !== project.id).forEach((p) => map.set(`${p.name} (#${p.id})`, p.id));
+    return map;
+  }, [allProjects, project.id]);
+
+  const handleSelectMap = useCallback((mapName: string) => {
+    setSelectedMap(mapName);
+    setSelectedFile(null);
+    setLocalBuffer(null);
+    setLocalFileType(null);
+  }, []);
+
+  const handleFileSelect = useCallback(async (file: File | null) => {
+    if (!file) return;
+    const fileType = getModelFileType(file.name);
+    if (!fileType) {
+      setSelectedFile(null);
+      setLocalBuffer(null);
+      setLocalFileType(null);
+      return;
+    }
+    setSelectedFile(file);
+    setLocalFileType(fileType);
+    setLocalBuffer(await file.arrayBuffer());
+  }, []);
+
+  const handleUpload = useCallback(async () => {
+    if (!selectedFile || !selectedMap) return;
+    try {
+      await uploadMapData.mutateAsync({ projectId: project.id, mapName: selectedMap, file: selectedFile, transform: alignmentToTransform(align) });
+      showToast('Upload successful', 2, 'success');
+      setSelectedFile(null);
+      setLocalBuffer(null);
+      setLocalFileType(null);
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : 'Upload failed', 3, 'error');
+    }
+  }, [selectedFile, selectedMap, uploadMapData, project.id, align, showToast]);
+
+  const handleSave = useCallback(async () => {
+    if (!selectedMap) return;
+    try {
+      await updateMapTransform.mutateAsync({ projectId: project.id, mapName: selectedMap, transform: alignmentToTransform(align) });
+      showToast('Alignment saved', 2, 'success');
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : 'Failed to save alignment', 3, 'error');
+    }
+  }, [selectedMap, updateMapTransform, project.id, align, showToast]);
+
+  const handleImport = useCallback(async () => {
+    const sourceProjectId = importSourceOptions.get(importSourceLabel);
+    if (!selectedMap || sourceProjectId === undefined) return;
+    try {
+      await importMap.mutateAsync({ projectId: project.id, mapName: selectedMap, sourceProjectId });
+      showToast('Import successful', 2, 'success');
+      setImportSourceLabel('');
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : 'Import failed', 3, 'error');
+    }
+  }, [importSourceOptions, importSourceLabel, selectedMap, importMap, project.id, showToast]);
+
+  const previewBuffer = localBuffer ?? serverModel?.buffer ?? null;
+  const previewFileType = localBuffer ? localFileType : (serverModel?.fileType ?? null);
+  const patch = (p: Partial<Alignment>) => setAlign((prev) => ({ ...prev, ...p }));
+
+  return (
+    <div className={className}>
+      <FlexColumn gap={16} align='flex-start'>
+        <FlexColumn gap={4} align='flex-start'>
+          <Text text='Map' />
+          <Selector onChange={handleSelectMap} options={maps ?? []} value={selectedMap} fontSize='sm' disabled={(maps ?? []).length === 0} />
+        </FlexColumn>
+
+        {selectedMap && (
+          <>
+            <div className={`${className}__preview`}>
+              {previewBuffer ? (
+                <MapModelPreview
+                  buffer={previewBuffer}
+                  fileType={previewFileType}
+                  position={[align.modelPositionX, align.modelPositionY, align.modelPositionZ]}
+                  rotationDeg={[align.modelRotationX, align.modelRotationY, align.modelRotationZ]}
+                  scale={align.scale}
+                />
+              ) : (
+                <div className={`${className}__empty`}>
+                  <Text text='No model uploaded for this map yet.' />
+                </div>
+              )}
+            </div>
+
+            <FlexColumn gap={8} align='flex-start'>
+              <Text text='Position' />
+              <FlexRow gap={4} align='center'>
+                <DraggableNumberInput label='X' value={align.modelPositionX} onChange={(v) => patch({ modelPositionX: v })} step={1} precision={0} />
+                <DraggableNumberInput label='Y' value={align.modelPositionY} onChange={(v) => patch({ modelPositionY: v })} step={1} precision={0} />
+                <DraggableNumberInput label='Z' value={align.modelPositionZ} onChange={(v) => patch({ modelPositionZ: v })} step={1} precision={0} />
+              </FlexRow>
+              <Text text='Rotation' />
+              <FlexRow gap={4} align='center'>
+                <DraggableNumberInput
+                  label='X'
+                  value={align.modelRotationX}
+                  onChange={(v) => patch({ modelRotationX: v })}
+                  min={-180}
+                  max={180}
+                  step={1}
+                  precision={0}
+                />
+                <DraggableNumberInput
+                  label='Y'
+                  value={align.modelRotationY}
+                  onChange={(v) => patch({ modelRotationY: v })}
+                  min={-180}
+                  max={180}
+                  step={1}
+                  precision={0}
+                />
+                <DraggableNumberInput
+                  label='Z'
+                  value={align.modelRotationZ}
+                  onChange={(v) => patch({ modelRotationZ: v })}
+                  min={-180}
+                  max={180}
+                  step={1}
+                  precision={0}
+                />
+              </FlexRow>
+              <Text text='Scale' />
+              <DraggableNumberInput label='S' value={align.scale} onChange={(v) => patch({ scale: v })} min={0.01} step={0.1} precision={2} />
+              <FlexRow gap={8} align='center'>
+                <Button scheme='tertiary' fontSize='sm' onClick={() => setAlign(IDENTITY)}>
+                  <Text text='Reset' />
+                </Button>
+                <Button scheme='primary' fontSize='sm' onClick={handleSave} disabled={updateMapTransform.isPending}>
+                  <Text text={updateMapTransform.isPending ? 'Saving...' : 'Save alignment'} />
+                </Button>
+              </FlexRow>
+            </FlexColumn>
+
+            <FlexColumn gap={8} align='flex-start'>
+              <Text text={`Upload 3D model for "${selectedMap}"`} />
+              <FlexRow gap={8} align='center'>
+                <FileInput accept='.obj,.fbx' onChange={handleFileSelect} buttonText='Select OBJ/FBX File' fontSize='sm' />
+                {selectedFile && <Text text={selectedFile.name} />}
+              </FlexRow>
+              <Button scheme='primary' fontSize='sm' onClick={handleUpload} disabled={!selectedFile || uploadMapData.isPending}>
+                <Text text={uploadMapData.isPending ? 'Uploading...' : 'Upload'} />
+              </Button>
+            </FlexColumn>
+
+            {importSourceOptions.size > 0 && (
+              <FlexColumn gap={8} align='flex-start'>
+                <Text text={`Import "${selectedMap}" from another project`} />
+                <Selector
+                  onChange={setImportSourceLabel}
+                  options={Array.from(importSourceOptions.keys())}
+                  value={importSourceLabel}
+                  fontSize='sm'
+                  disabled={importMap.isPending}
+                />
+                <Button scheme='secondary' fontSize='sm' onClick={handleImport} disabled={!importSourceLabel || importMap.isPending}>
+                  <Text text={importMap.isPending ? 'Importing...' : 'Import'} />
+                </Button>
+              </FlexColumn>
+            )}
+          </>
+        )}
+      </FlexColumn>
+    </div>
+  );
+};
+
+export const ProjectDetailsMapsTab = styled(Component)`
+  width: 100%;
+
+  &__preview {
+    width: 100%;
+    height: 360px;
+    overflow: hidden;
+    background: ${({ theme }) => theme.colors.surface.sunken};
+    border: 1px solid ${({ theme }) => theme.colors.border.default};
+    border-radius: 8px;
+  }
+
+  &__empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+  }
+`;


### PR DESCRIPTION
## 概要

heatmap ビューアを開かなくても、**プロジェクト詳細ページから map のモデルを管理**できる「Maps」タブを追加します。アップロード・配置調整（位置/回転/スケール）・別プロジェクトからのインポートを、3Dプレビュー付きで行えます。

> **base はあえて `feat/model-per-project-ui`（#469）です。** このタブは per-project の新フック（projectId スコープ）に依存するため #469 にスタックしています。マージ順は #469 → spec(#467) → develop が先、その後このPRを develop 向けに付け替え（or #469 取込後に rebase）想定です。

## 変更内容

- **`MapModelPreview`**（新規）: heatmap の Redux/Canvas に依存しない軽量な R3F ビューア。`useModelFromArrayBuffer`（FBX/OBJ）でモデル読込、ライト + OrbitControls、position/rotation(度)/scale を反映。モデル読込時にカメラを自動フィット
- **`ProjectDetailsMapsTab`**（新規）: マップ選択 → 3Dプレビュー + 配置エディタ（数値入力）+ アクション（アップロード / 配置保存 / 別プロジェクトからインポート）。サーバーの transform で初期化、ローカルファイル選択時はプレビューに即反映
- **プロジェクト詳細ページ**: 「Maps」タブ（Sessions/**Maps**/Members/API Keys）を結線

## 設計方針

- heatmap 側と独立した自己完結コンポーネント（既存の per-project フック・`modelTransform`・`useModelFromArrayBuffer` を再利用）
- ギズモ（ドラッグ）は無し。位置/回転/スケールは数値入力（必要なら後続）

## 確認方法

per-project API（#236）+ #469/#467 反映済み環境で:
1. プロジェクト詳細 → **Maps タブ**
2. マップ選択 → 3Dでモデル表示
3. 位置/回転/スケール調整 → プレビューに即反映 → Save alignment
4. OBJ/FBX アップロード / 別プロジェクトからインポート

## 品質チェック
- `bun run type` ✅ / `bun run lint` ✅ / `bun run format:check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
