### PR TITLE
🧹 chore: remove commented out debug logs in HeatmapCanvas

### DIFF
--- a/src/features/heatmap/HeatmapCanvas.tsx
+++ b/src/features/heatmap/HeatmapCanvas.tsx
@@ -241,7 +241,6 @@ const HeatMapCanvasComponent: FC<HeatmapCanvasProps> = ({
       const defaultZ = DEFAULT_WAYPOINT_Z;
       const hit = getHeightOnModel(defaultX, defaultZ);
       if (!hit) {
-        // console.warn('モデル表面の交差点が見つかりませんでした');
         return;
       }
 
@@ -249,7 +248,6 @@ const HeatMapCanvasComponent: FC<HeatmapCanvasProps> = ({
         id: crypto.randomUUID(), // または任意の一意な文字列生成
         position: hit.clone(),
       };
-      // console.log('新しいウェイポイントを追加:', newWp, '位置:', newWp.position);
       setWaypoints((prev) => [...prev, newWp]);
       setSelectedWaypointId(newWp.id); // 追加後に自動で選択状態にする
     };
@@ -424,7 +422,6 @@ const HeatMapCanvasComponent: FC<HeatmapCanvasProps> = ({
       const max = controls.maxDistance ?? fitDist * MAX_DISTANCE_MULTIPLIER;
 
       const targetDist = clamp(fitDist * (ZOOM_BASE_VALUE / clamp(percent, ZOOM_MIN_PERCENT, ZOOM_MAX_PERCENT)), min, max);
-      // console.log('targetDist', targetDist, 'min', min, 'max', max, 'percent', percent);
 
       const cam = camera as PerspectiveCamera;
       const dir = cam.position.clone().sub(controls.target).normalize();


### PR DESCRIPTION
🎯 **What:** Removed commented-out debug code (`console.log` and `console.warn`) from `src/features/heatmap/HeatmapCanvas.tsx`.
💡 **Why:** Dead debug code clutters the file and provides no functional value. Removing it improves code maintainability and readability without altering behavior.
✅ **Verification:** Ran `bun install`, `bun run lint` and `npm run test` to verify no regressions were introduced.
✨ **Result:** A cleaner file with no commented-out log statements, improving code health.

---
*PR created automatically by Jules for task [14231373486338663448](https://jules.google.com/task/14231373486338663448) started by @Matuyuhi*